### PR TITLE
Logic For Building Image on Additional Architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,16 @@ WORKDIR /usr/src/app
 RUN apk --no-cache add curl jq
 
 RUN latest_release=$(curl --silent "https://api.github.com/repos/donetick/donetick/releases/latest" | jq -r .tag_name) && \
-curl -fL "https://github.com/donetick/donetick/releases/download/${latest_release}/donetick_Linux_x86_64.tar.gz" | tar -xz -C .
+    set -ex; \
+    apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+    armhf) arch='armv6' ;; \
+    armv7) arch='armv7' ;; \
+    aarch64) arch='arm64' ;; \
+    x86_64) arch='x86_64' ;; \
+    *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+    esac; \
+    curl -fL "https://github.com/donetick/donetick/releases/download/${latest_release}/donetick_Linux_$arch.tar.gz" | tar -xz -C .
 
 # Stage 2: Create a smaller runtime image
 FROM alpine:latest


### PR DESCRIPTION
Added some logic to the dockerfile that determines the arch used for building and downloads the correct release from GitHub.