### PR TITLE
Bugfix: error when disabling push notifications

### DIFF
--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -507,7 +507,7 @@ func (h *Handler) UpdateNotificationTarget(c *gin.Context) {
 
 	type Request struct {
 		Type   nModel.NotificationType `json:"type"`
-		Target string                  `json:"target" binding:"required"`
+		Target string                  `json:"target"`
 	}
 
 	var req Request


### PR DESCRIPTION
Target is currently set to required but when choosing the "None" option in the UI, the HTTP request fails with status code 400 due to that parameter being required by the service. 