### PR TITLE
Add backend logic for mqtt notifications

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Name                   string          `mapstructure:"name" yaml:"name"`
 	Telegram               TelegramConfig  `mapstructure:"telegram" yaml:"telegram"`
 	Pushover               PushoverConfig  `mapstructure:"pushover" yaml:"pushover"`
+	Mqtt                   MqttConfig      `mapstructure:"mqtt" yaml:"mqtt"`
 	Database               DatabaseConfig  `mapstructure:"database" yaml:"database"`
 	Jwt                    JwtConfig       `mapstructure:"jwt" yaml:"jwt"`
 	Server                 ServerConfig    `mapstructure:"server" yaml:"server"`
@@ -28,6 +29,16 @@ type TelegramConfig struct {
 
 type PushoverConfig struct {
 	Token string `mapstructure:"token" yaml:"token"`
+}
+
+type MqttConfig struct {
+	Host     string `mapstructure:"host" yaml:"host"`
+	Port     int    `mapstructure:"port" yaml:"port"`
+	UseTls   bool   `mapstructure:"use_tls" yaml:"use_tls"`
+	Username string `mapstructure:"username" yaml:"username"`
+	Password string `mapstructure:"password" yaml:"password"`
+	ClientId string `mapstructure:"client_id" yaml:"client_id"`
+	Topic    string `mapstructure:"topic" yaml:"topic"`
 }
 
 type DatabaseConfig struct {

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -8,6 +8,14 @@ pushover:
 database:
   type: "sqlite"
   migration: true
+mqtt:
+  host: ""
+  port: 1883
+  use_tls: false
+  username: ""
+  password: ""
+  client_id: "donetick"
+  topic: "donetick"
 jwt:
   secret: "secret"
   session_time: 168h

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -5,6 +5,14 @@ telegram:
   token: ""
 pushover:
   token: ""
+mqtt:
+  host: ""
+  port: 8883
+  use_tls: true
+  username: ""
+  password: ""
+  client_id: "donetick"
+  topic: "donetick"
 database:
   type: "sqlite"
   migration: true

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/eclipse/paho.golang v0.22.0 // indirect
+	github.com/eclipse/paho.mqtt.golang v1.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.4 // indirect
@@ -50,6 +52,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gregdel/pushover v1.3.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/eclipse/paho.golang v0.22.0 h1:JhhUngr8TBlyUZDZw/L6WVayPi9qmSmdWeki48i5AVE=
+github.com/eclipse/paho.golang v0.22.0/go.mod h1:9ZiYJ93iEfGRJri8tErNeStPKLXIGBHiqbHV74t5pqI=
+github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
+github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -108,6 +112,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.4 h1:9gWcmF85Wvq4ryPFvGFaOgPIs1AQX0d0bcbGw4Z96qg=
 github.com/googleapis/gax-go/v2 v2.12.4/go.mod h1:KYEYLorsnIGDi/rPC8b5TdlB9kbKoFubselGIoBMCwI=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregdel/pushover v1.3.1 h1:4bMLITOZ15+Zpi6qqoGqOPuVHCwSUvMCgVnN5Xhilfo=
 github.com/gregdel/pushover v1.3.1/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER1PthX7to=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -225,6 +231,7 @@ go.uber.org/fx v1.22.0 h1:pApUK7yL0OUHMd8vkunWSlLxZVFFk70jR2nKde8X2NM=
 go.uber.org/fx v1.22.0/go.mod h1:HT2M7d7RHo+ebKGh9NRcrsrHHfpZ60nW3QRubMRfv48=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=

--- a/internal/notifier/model/model.go
+++ b/internal/notifier/model/model.go
@@ -23,6 +23,8 @@ func (n *Notification) IsValid() bool {
 			return false
 		}
 		return true
+	case NotificationTypeMqtt:
+		return true
 	default:
 		return false
 	}
@@ -34,4 +36,5 @@ const (
 	NotificationTypeNone NotificationType = iota
 	NotificationTypeTelegram
 	NotificationTypePushover
+	NotificationTypeMqtt
 )

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	nModel "donetick.com/core/internal/notifier/model"
+	mqtt "donetick.com/core/internal/notifier/service/mqtt"
 	pushover "donetick.com/core/internal/notifier/service/pushover"
 	telegram "donetick.com/core/internal/notifier/service/telegram"
 	"donetick.com/core/logging"
@@ -12,12 +13,14 @@ import (
 type Notifier struct {
 	Telegram *telegram.TelegramNotifier
 	Pushover *pushover.Pushover
+	Mqtt     *mqtt.MqttNotifier
 }
 
-func NewNotifier(t *telegram.TelegramNotifier, p *pushover.Pushover) *Notifier {
+func NewNotifier(t *telegram.TelegramNotifier, p *pushover.Pushover, m *mqtt.MqttNotifier) *Notifier {
 	return &Notifier{
 		Telegram: t,
 		Pushover: p,
+		Mqtt:     m,
 	}
 }
 
@@ -36,6 +39,13 @@ func (n *Notifier) SendNotification(c context.Context, notification *nModel.Noti
 			return nil
 		}
 		return n.Pushover.SendNotification(c, notification)
+	case nModel.NotificationTypeMqtt:
+		if n.Mqtt == nil {
+			log.Error("Mqtt is not initialized, Skipping sending message")
+			return nil
+		}
+		return n.Mqtt.SendNotification(c, notification)
 	}
+
 	return nil
 }

--- a/internal/notifier/service/mqtt/mqtt.go
+++ b/internal/notifier/service/mqtt/mqtt.go
@@ -1,0 +1,47 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"donetick.com/core/config"
+	nModel "donetick.com/core/internal/notifier/model"
+	"donetick.com/core/logging"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+type MqttNotifier struct {
+	client MQTT.Client
+	topic  string
+}
+
+func NewMqttNotifier(config *config.Config) *MqttNotifier {
+	client := MQTT.NewClient(
+		MQTT.NewClientOptions().AddBroker(config.Mqtt.Host).SetClientID(config.Mqtt.ClientId).SetUsername(config.Mqtt.Username).SetPassword(config.Mqtt.Password))
+
+	if token := client.Connect(); token.WaitTimeout(time.Second*4) && token.Error() != nil {
+		fmt.Printf("Failed to connect to MQTT broker: %v", token.Error())
+	} else {
+		fmt.Println("Connected to MQTT broker")
+	}
+
+	return &MqttNotifier{
+		client,
+		config.Mqtt.Topic,
+	}
+}
+
+func (m *MqttNotifier) SendNotification(c context.Context, notification *nModel.Notification) error {
+	log := logging.FromContext(c)
+
+	token := m.client.Publish(m.topic, 0, false, "testing").WaitTimeout(time.Second * 4)
+	if token {
+		log.Info("Mqtt notification delivered")
+		return nil
+	} else {
+		log.Error("Mqtt notification failed")
+		return errors.New("mqtt notification failed")
+	}
+}

--- a/internal/notifier/service/mqtt/mqtt.go
+++ b/internal/notifier/service/mqtt/mqtt.go
@@ -36,7 +36,7 @@ func NewMqttNotifier(config *config.Config) *MqttNotifier {
 func (m *MqttNotifier) SendNotification(c context.Context, notification *nModel.Notification) error {
 	log := logging.FromContext(c)
 
-	token := m.client.Publish(m.topic, 0, false, "testing").WaitTimeout(time.Second * 4)
+	token := m.client.Publish(m.topic, 0, false, notification.Text).WaitTimeout(time.Second * 4)
 	if token {
 		log.Info("Mqtt notification delivered")
 		return nil

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	notifier "donetick.com/core/internal/notifier"
 	nRepo "donetick.com/core/internal/notifier/repo"
 	nps "donetick.com/core/internal/notifier/service"
+	mqtt "donetick.com/core/internal/notifier/service/mqtt"
 	"donetick.com/core/internal/notifier/service/pushover"
 	telegram "donetick.com/core/internal/notifier/service/telegram"
 	"donetick.com/core/internal/thing"
@@ -67,6 +68,7 @@ func main() {
 		// add notifier
 		fx.Provide(pushover.NewPushover),
 		fx.Provide(telegram.NewTelegramNotifier),
+		fx.Provide(mqtt.NewMqttNotifier),
 		fx.Provide(notifier.NewNotifier),
 
 		// Rate limiter


### PR DESCRIPTION
The current notification providers don't offer a fully sandboxed / self-hosted / disconnected notification system.
This is an initial design for single topic mqtt notification which can be completely set up locally without requiring an external service to the environment donetick is running in. 

In a future change it might become interesting to develop a more complex topic system that caters to multiple user scenarios and possibly multiple types of notifications so they can be treated differently by subscribed clients.

Tracking this feature with [this issue](https://github.com/dkhalife/donetick/issues/12)