### PR TITLE
Add support for webhooks as a notification target

### DIFF
--- a/internal/circle/model/model.go
+++ b/internal/circle/model/model.go
@@ -39,4 +39,6 @@ type UserCircleDetail struct {
 	DisplayName      string                  `json:"displayName" gorm:"column:display_name"`
 	NotificationType nModel.NotificationType `json:"-" gorm:"column:notification_type"`
 	TargetID         string                  `json:"-" gorm:"column:target_id"` // Target ID
+	WebhookURL       string                  `json:"webhook_url" gorm:"column:webhook_url"`
+	WebhookMethod    nModel.WebhookMethod    `json:"webhook_method" gorm:"column:webhook_method"`
 }

--- a/internal/circle/repo/repository.go
+++ b/internal/circle/repo/repository.go
@@ -43,7 +43,7 @@ func (r *CircleRepository) GetCircleUsers(c context.Context, circleID int) ([]*c
 	var circleUsers []*cModel.UserCircleDetail
 	if err := r.db.WithContext(c).
 		Table("user_circles uc").
-		Select("uc.*, u.username, u.display_name, u.chat_id,  unt.user_id as user_id, unt.target_id as target_id, unt.type as notification_type").
+		Select("uc.*, u.username, u.display_name, u.chat_id,  unt.user_id as user_id, unt.target_id as target_id, unt.type as notification_type, unt.webhook_url, unt.webhook_method").
 		Joins("left join users u on u.id = uc.user_id").
 		Joins("left join user_notification_targets unt on unt.user_id = u.id").
 		Where("uc.circle_id = ?", circleID).

--- a/internal/notifier/model/model.go
+++ b/internal/notifier/model/model.go
@@ -2,16 +2,25 @@ package model
 
 import "time"
 
+type WebhookMethod string
+
+const (
+	GET  WebhookMethod = "GET"
+	POST WebhookMethod = "POST"
+)
+
 type Notification struct {
-	ID           int              `json:"id" gorm:"primaryKey"`
-	ChoreID      int              `json:"chore_id" gorm:"column:chore_id"`
-	UserID       int              `json:"user_id" gorm:"column:user_id"`
-	TargetID     string           `json:"target_id" gorm:"column:target_id"`
-	Text         string           `json:"text" gorm:"column:text"`
-	IsSent       bool             `json:"is_sent" gorm:"column:is_sent;index;default:false"`
-	TypeID       NotificationType `json:"type" gorm:"column:type"`
-	ScheduledFor time.Time        `json:"scheduled_for" gorm:"column:scheduled_for;index"`
-	CreatedAt    time.Time        `json:"created_at" gorm:"column:created_at"`
+	ID            int              `json:"id" gorm:"primaryKey"`
+	ChoreID       int              `json:"chore_id" gorm:"column:chore_id"`
+	UserID        int              `json:"user_id" gorm:"column:user_id"`
+	TargetID      string           `json:"target_id" gorm:"column:target_id"`
+	Text          string           `json:"text" gorm:"column:text"`
+	IsSent        bool             `json:"is_sent" gorm:"column:is_sent;index;default:false"`
+	TypeID        NotificationType `json:"type" gorm:"column:type"`
+	ScheduledFor  time.Time        `json:"scheduled_for" gorm:"column:scheduled_for;index"`
+	CreatedAt     time.Time        `json:"created_at" gorm:"column:created_at"`
+	WebhookURL    string           `json:"webhook_url" gorm:"column:webhook_url"`
+	WebhookMethod WebhookMethod    `json:"webhook_method" gorm:"column:webhook_method"`
 }
 
 func (n *Notification) IsValid() bool {
@@ -20,6 +29,14 @@ func (n *Notification) IsValid() bool {
 		if n.TargetID == "" {
 			return false
 		} else if n.Text == "0" {
+			return false
+		}
+		return true
+	case NotificationTypeWebhook:
+		if n.WebhookURL == "" {
+			return false
+		}
+		if n.WebhookMethod != GET && n.WebhookMethod != POST {
 			return false
 		}
 		return true
@@ -34,4 +51,5 @@ const (
 	NotificationTypeNone NotificationType = iota
 	NotificationTypeTelegram
 	NotificationTypePushover
+	NotificationTypeWebhook
 )

--- a/internal/notifier/service/planner.go
+++ b/internal/notifier/service/planner.go
@@ -81,14 +81,16 @@ func generateDueNotifications(chore *chModel.Chore, users []*cModel.UserCircleDe
 	}
 	for _, user := range users {
 		notification := &nModel.Notification{
-			ChoreID:      chore.ID,
-			IsSent:       false,
-			ScheduledFor: *chore.NextDueDate,
-			CreatedAt:    time.Now().UTC(),
-			TypeID:       user.NotificationType,
-			UserID:       user.ID,
-			TargetID:     user.TargetID,
-			Text:         fmt.Sprintf("📅 Reminder: *%s* is due today and assigned to %s.", chore.Name, assignee.DisplayName),
+			ChoreID:       chore.ID,
+			IsSent:        false,
+			ScheduledFor:  *chore.NextDueDate,
+			CreatedAt:     time.Now().UTC(),
+			TypeID:        user.NotificationType,
+			UserID:        user.ID,
+			TargetID:      user.TargetID,
+			WebhookURL:    user.WebhookURL,
+			WebhookMethod: user.WebhookMethod,
+			Text:          fmt.Sprintf("📅 Reminder: *%s* is due today and assigned to %s.", chore.Name, assignee.DisplayName),
 		}
 		if notification.IsValid() {
 			notifications = append(notifications, notification)
@@ -109,14 +111,16 @@ func generatePreDueNotifications(chore *chModel.Chore, users []*cModel.UserCircl
 	notifications := make([]*nModel.Notification, 0)
 	for _, user := range users {
 		notification := &nModel.Notification{
-			ChoreID:      chore.ID,
-			IsSent:       false,
-			ScheduledFor: *chore.NextDueDate,
-			CreatedAt:    time.Now().UTC().Add(-time.Hour * 3),
-			TypeID:       user.NotificationType,
-			UserID:       user.ID,
-			TargetID:     user.TargetID,
-			Text:         fmt.Sprintf("📢 Heads up! *%s* is due soon (on %s) and assigned to %s.", chore.Name, chore.NextDueDate.Format("January 2nd"), assignee.DisplayName),
+			ChoreID:       chore.ID,
+			IsSent:        false,
+			ScheduledFor:  *chore.NextDueDate,
+			CreatedAt:     time.Now().UTC().Add(-time.Hour * 3),
+			TypeID:        user.NotificationType,
+			UserID:        user.ID,
+			TargetID:      user.TargetID,
+			WebhookURL:    user.WebhookURL,
+			WebhookMethod: user.WebhookMethod,
+			Text:          fmt.Sprintf("📢 Heads up! *%s* is due soon (on %s) and assigned to %s.", chore.Name, chore.NextDueDate.Format("January 2nd"), assignee.DisplayName),
 		}
 		if notification.IsValid() {
 			notifications = append(notifications, notification)
@@ -140,14 +144,16 @@ func generateOverdueNotifications(chore *chModel.Chore, users []*cModel.UserCirc
 		scheduleTime := chore.NextDueDate.Add(time.Hour * time.Duration(hours))
 		for _, user := range users {
 			notification := &nModel.Notification{
-				ChoreID:      chore.ID,
-				IsSent:       false,
-				ScheduledFor: scheduleTime,
-				CreatedAt:    time.Now().UTC(),
-				TypeID:       user.NotificationType,
-				UserID:       user.ID,
-				TargetID:     fmt.Sprint(user.TargetID),
-				Text:         fmt.Sprintf("🚨 *%s* is now %d hours overdue. Please complete it as soon as possible. (Assigned to %s)", chore.Name, hours, assignee.DisplayName),
+				ChoreID:       chore.ID,
+				IsSent:        false,
+				ScheduledFor:  scheduleTime,
+				CreatedAt:     time.Now().UTC(),
+				TypeID:        user.NotificationType,
+				UserID:        user.ID,
+				TargetID:      fmt.Sprint(user.TargetID),
+				WebhookURL:    user.WebhookURL,
+				WebhookMethod: user.WebhookMethod,
+				Text:          fmt.Sprintf("🚨 *%s* is now %d hours overdue. Please complete it as soon as possible. (Assigned to %s)", chore.Name, hours, assignee.DisplayName),
 			}
 			if notification.IsValid() {
 				notifications = append(notifications, notification)
@@ -172,7 +178,9 @@ func generateCircleGroupNotifications(chore *chModel.Chore, mt *chModel.Notifica
 			CreatedAt:    time.Now().UTC(),
 			TypeID:       1,
 			TargetID:     fmt.Sprint(*mt.CircleGroupID),
-			Text:         fmt.Sprintf("📅 Reminder: *%s* is due today.", chore.Name),
+			//WebhookURL:    ?.WebhookURL,
+			//WebhookMethod: ?.WebhookMethod,
+			Text: fmt.Sprintf("📅 Reminder: *%s* is due today.", chore.Name),
 		}
 		if notification.IsValid() {
 			notifications = append(notifications, notification)
@@ -187,7 +195,9 @@ func generateCircleGroupNotifications(chore *chModel.Chore, mt *chModel.Notifica
 			CreatedAt:    time.Now().UTC().Add(-time.Hour * 3),
 			TypeID:       3,
 			TargetID:     fmt.Sprint(*mt.CircleGroupID),
-			Text:         fmt.Sprintf("📢 Heads up! *%s* is due soon (on %s).", chore.Name, chore.NextDueDate.Format("January 2nd")),
+			//WebhookURL:    ?.WebhookURL,
+			//WebhookMethod: ?.WebhookMethod,
+			Text: fmt.Sprintf("📢 Heads up! *%s* is due soon (on %s).", chore.Name, chore.NextDueDate.Format("January 2nd")),
 		}
 		if notification.IsValid() {
 			notifications = append(notifications, notification)
@@ -204,7 +214,9 @@ func generateCircleGroupNotifications(chore *chModel.Chore, mt *chModel.Notifica
 				CreatedAt:    time.Now().UTC(),
 				TypeID:       2,
 				TargetID:     fmt.Sprint(*mt.CircleGroupID),
-				Text:         fmt.Sprintf("🚨 *%s* is now %d hours overdue. Please complete it as soon as possible.", chore.Name, hours),
+				//WebhookURL:    ?.WebhookURL,
+				//WebhookMethod: ?.WebhookMethod,
+				Text: fmt.Sprintf("🚨 *%s* is now %d hours overdue. Please complete it as soon as possible.", chore.Name, hours),
 			}
 			if notification.IsValid() {
 				notifications = append(notifications, notification)

--- a/internal/notifier/service/webhook/webhook.go
+++ b/internal/notifier/service/webhook/webhook.go
@@ -1,0 +1,67 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"donetick.com/core/config"
+	nModel "donetick.com/core/internal/notifier/model"
+	"donetick.com/core/logging"
+)
+
+type WebhookNotifier struct {
+}
+
+func NewWebhookNotifier(config *config.Config) *WebhookNotifier {
+	return &WebhookNotifier{}
+}
+
+func (m *WebhookNotifier) SendNotification(c context.Context, notification *nModel.Notification) error {
+	log := logging.FromContext(c)
+
+	notificationData := map[string]string{
+		"choreId": strconv.Itoa(notification.ChoreID),
+		"userId":  strconv.Itoa(notification.UserID),
+		"text":    notification.Text,
+	}
+
+	notificationJSON, err := json.Marshal(notificationData)
+	if err != nil {
+		log.Error("Error marshalling notification data to JSON", "error", err)
+		return err
+	}
+
+	log.Debug("Sending webhook notification", "notification", notification)
+	if notification.WebhookMethod == "GET" {
+		req, err := http.NewRequest("GET", notification.WebhookURL, nil)
+		if err != nil {
+			log.Error("Error creating GET request", "error", err)
+			return err
+		}
+		q := req.URL.Query()
+		for key, value := range notificationData {
+			q.Add(key, value)
+		}
+		req.URL.RawQuery = q.Encode()
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Error("Error making GET request", "error", err)
+			return err
+		}
+		defer resp.Body.Close()
+	} else if notification.WebhookMethod == "POST" {
+		resp, err := http.Post(notification.WebhookURL, "application/json", bytes.NewBuffer(notificationJSON))
+		if err != nil {
+			log.Error("Error making POST request", "error", err)
+			return err
+		}
+		defer resp.Body.Close()
+	}
+
+	return nil
+}

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -506,8 +506,10 @@ func (h *Handler) UpdateNotificationTarget(c *gin.Context) {
 	}
 
 	type Request struct {
-		Type   nModel.NotificationType `json:"type"`
-		Target string                  `json:"target"`
+		Type          nModel.NotificationType `json:"type"`
+		Target        string                  `json:"target"`
+		WebhookMethod nModel.WebhookMethod    `json:"webhook_method"`
+		WebhookURL    string                  `json:"webhook_url"`
 	}
 
 	var req Request
@@ -525,13 +527,13 @@ func (h *Handler) UpdateNotificationTarget(c *gin.Context) {
 		return
 	}
 
-	err := h.userRepo.UpdateNotificationTarget(c, currentUser.ID, req.Target, req.Type)
+	err := h.userRepo.UpdateNotificationTarget(c, currentUser.ID, req.Target, req.Type, req.WebhookMethod, req.WebhookURL)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update notification target"})
 		return
 	}
 
-	err = h.userRepo.UpdateNotificationTargetForAllNotifications(c, currentUser.ID, req.Target, req.Type)
+	err = h.userRepo.UpdateNotificationTargetForAllNotifications(c, currentUser.ID, req.Target, req.Type, req.WebhookMethod, req.WebhookURL)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update notification target for all notifications"})
 		return

--- a/internal/user/model/model.go
+++ b/internal/user/model/model.go
@@ -43,8 +43,10 @@ type APIToken struct {
 }
 
 type UserNotificationTarget struct {
-	UserID    int                     `json:"userId" gorm:"column:user_id;index;primaryKey"` // Index on userID
-	Type      nModel.NotificationType `json:"type" gorm:"column:type"`                       // Type
-	TargetID  string                  `json:"target_id" gorm:"column:target_id"`             // Target ID
-	CreatedAt time.Time               `json:"-" gorm:"column:created_at"`
+	UserID        int                     `json:"userId" gorm:"column:user_id;index;primaryKey"` // Index on userID
+	Type          nModel.NotificationType `json:"type" gorm:"column:type"`                       // Type
+	TargetID      string                  `json:"target_id" gorm:"column:target_id"`             // Target ID
+	WebhookURL    string                  `json:"webhook_url" gorm:"column:webhook_url"`         // Webhook URL
+	WebhookMethod nModel.WebhookMethod    `json:"webhook_method" gorm:"column:webhook_method"`   // Webhook Method
+	CreatedAt     time.Time               `json:"-" gorm:"column:created_at"`
 }

--- a/internal/user/repo/repository.go
+++ b/internal/user/repo/repository.go
@@ -160,12 +160,14 @@ func (r *UserRepository) DeleteAPIToken(c context.Context, userID int, tokenID s
 	return r.db.WithContext(c).Where("id = ? AND user_id = ?", tokenID, userID).Delete(&uModel.APIToken{}).Error
 }
 
-func (r *UserRepository) UpdateNotificationTarget(c context.Context, userID int, targetID string, targetType nModel.NotificationType) error {
+func (r *UserRepository) UpdateNotificationTarget(c context.Context, userID int, targetID string, targetType nModel.NotificationType, webhookMethod nModel.WebhookMethod, WebhookURL string) error {
 	return r.db.WithContext(c).Save(&uModel.UserNotificationTarget{
-		UserID:    userID,
-		TargetID:  targetID,
-		Type:      targetType,
-		CreatedAt: time.Now().UTC(),
+		UserID:        userID,
+		TargetID:      targetID,
+		Type:          targetType,
+		CreatedAt:     time.Now().UTC(),
+		WebhookURL:    WebhookURL,
+		WebhookMethod: webhookMethod,
 	}).Error
 }
 
@@ -173,7 +175,7 @@ func (r *UserRepository) DeleteNotificationTarget(c context.Context, userID int)
 	return r.db.WithContext(c).Where("user_id = ?", userID).Delete(&uModel.UserNotificationTarget{}).Error
 }
 
-func (r *UserRepository) UpdateNotificationTargetForAllNotifications(c context.Context, userID int, targetID string, targetType nModel.NotificationType) error {
+func (r *UserRepository) UpdateNotificationTargetForAllNotifications(c context.Context, userID int, targetID string, targetType nModel.NotificationType, webhookMethod nModel.WebhookMethod, WebhookURL string) error {
 	return r.db.WithContext(c).Model(&nModel.Notification{}).Where("user_id = ?", userID).Update("target_id", targetID).Update("type", targetType).Error
 }
 func (r *UserRepository) UpdatePasswordByUserId(c context.Context, userID int, password string) error {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	nps "donetick.com/core/internal/notifier/service"
 	"donetick.com/core/internal/notifier/service/pushover"
 	telegram "donetick.com/core/internal/notifier/service/telegram"
+	"donetick.com/core/internal/notifier/service/webhook"
 	"donetick.com/core/internal/thing"
 	tRepo "donetick.com/core/internal/thing/repo"
 	"donetick.com/core/internal/user"
@@ -67,6 +68,7 @@ func main() {
 		// add notifier
 		fx.Provide(pushover.NewPushover),
 		fx.Provide(telegram.NewTelegramNotifier),
+		fx.Provide(webhook.NewWebhookNotifier),
 		fx.Provide(notifier.NewNotifier),
 
 		// Rate limiter

--- a/migrations/20250105_migrate_notification_target_to_notification_target_v2.go
+++ b/migrations/20250105_migrate_notification_target_to_notification_target_v2.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"context"
+
+	nModel "donetick.com/core/internal/notifier/model"
+	uModel "donetick.com/core/internal/user/model"
+	"donetick.com/core/logging"
+	"gorm.io/gorm"
+)
+
+type MigrateNotificationTarget20250105 struct{}
+
+func (m MigrateNotificationTarget20250105) ID() string {
+	return "20250105_migrate_notification_target_to_notification_target_v2"
+}
+
+func (m MigrateNotificationTarget20250105) Description() string {
+	return `Migrate notification target to notification target v2 table, Allows setting webhook as a notification target`
+}
+
+func (m MigrateNotificationTarget20250105) Down(ctx context.Context, db *gorm.DB) error {
+	return nil
+}
+
+func (m MigrateNotificationTarget20250105) Up(ctx context.Context, db *gorm.DB) error {
+	log := logging.FromContext(ctx)
+
+	// Create additional columns for webhook url and method
+	if err := db.AutoMigrate(&uModel.UserNotificationTarget{}); err != nil {
+		log.Errorf("Failed to update user_notification_targets table: %v", err)
+	}
+
+	// Similarly for the notifications table
+	if err := db.AutoMigrate(&nModel.Notification{}); err != nil {
+		log.Errorf("Failed to update notifications table: %v", err)
+	}
+
+	return nil
+}
+
+// Register this migration
+func init() {
+	Register(MigrateNotificationTarget20250105{})
+}

--- a/migrations/base.go
+++ b/migrations/base.go
@@ -60,7 +60,7 @@ func Run(ctx context.Context, db *gorm.DB) error {
 		db.Model(&Migration{}).Where("id = ?", migration.ID()).Count(&count)
 		if count > 0 {
 			skippedCount++
-			log.Debug("Skipping migration %s as it is already applied", migration.ID())
+			log.Debugf("Skipping migration %s as it is already applied", migration.ID())
 			continue
 		}
 


### PR DESCRIPTION
Added new webhook settings in user_notification_target
As discussed offline, replicated the settings across the notifications table to minimize table locking
Updated the notification logic to forward to a new webhook provider when the settings are valid
Added DB migration file

Test notes:
Verified migration works as expected when migrating up from an older version as well as first install
End-to-end tested the integration with the frontend change and successfully received the notification on the other end