### PR TITLE
bump to 10s on read and write timeout

### DIFF
--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -14,8 +14,8 @@ jwt:
   max_refresh: 168h
 server:
   port: 2021
-  read_timeout: 2s
-  write_timeout: 1s
+  read_timeout: 10s
+  write_timeout: 10ss
   rate_period: 60s
   rate_limit: 300
   cors_allow_origins:

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -15,7 +15,7 @@ jwt:
 server:
   port: 2021
   read_timeout: 10s
-  write_timeout: 10ss
+  write_timeout: 10s
   rate_period: 60s
   rate_limit: 300
   cors_allow_origins:


### PR DESCRIPTION
Currently on mobile donetick does not load. Increase the read and write timeouts to accommodate loading on mobile.