### PR TITLE
fix: postgres migration

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -8,6 +8,12 @@ pushover:
 database:
   type: "sqlite"
   migration: true
+  # these are only required for postgres
+  host: "secret"
+  port: "secret"
+  user: "secret"
+  password: "secret"
+  name: "secret"
 jwt:
   secret: "secret"
   session_time: 168h

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -8,6 +8,12 @@ pushover:
 database:
   type: "sqlite"
   migration: true
+  # these are only required for postgres
+  host: "secret"
+  port: "secret"
+  user: "secret"
+  password: "secret"
+  name: "secret"
 jwt:
   secret: "secret"
   session_time: 168h


### PR DESCRIPTION
Using postgres results in panic during migration due to "sqlite3" being hard-coded as the db dialect for performing `ScriptMigration`. This commit fixes this behavior by selecting the proper dialect from config.

See #129 for more details.

I considered simply deleting `MigrationScripts` since it doesn't seem to do anything useful now. https://github.com/donetick/donetick/commit/8198829b733b7c26be5b69787046f729f88c7480 indicates that there may be plans for future use so I opted to keep it.

To test this, first run postgres:
```sh
docker run --rm -d \
-e POSTGRES_DB=donetick \
-e POSTGRES_USER=donetick \
-e POSTGRES_PASSWORD=changeme \
-p 5432:5432 \
postgres:17.4-alpine
```

then run the app:
```sh
DT_DATABASE_TYPE=postgres \
DT_DATABASE_HOST=localhost \
DT_DATABASE_PORT=5432 \
DT_DATABASE_NAME=donetick \
DT_DATABASE_USER=donetick \
DT_DATABASE_PASSWORD=changeme \
go run main.go
```

Fixes: #129 
