### PR TITLE
feat: add chore create & update eapi endpoints

### DIFF
--- a/internal/authorization/eapi_middleware.go
+++ b/internal/authorization/eapi_middleware.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	cRepo "donetick.com/core/internal/circle/repo"
+	uModel "donetick.com/core/internal/user/model"
+	uRepo "donetick.com/core/internal/user/repo"
+	"github.com/gin-gonic/gin"
+	"log"
+	"strconv"
+)
+
+var AuthorizationHeader = "secretKey"
+var ImpersonationHeader = "actionUserId"
+
+func GetUserFromTokenRequest(c *gin.Context, userRepo *uRepo.UserRepository, circleRepo *cRepo.CircleRepository) (*uModel.UserDetails, bool) {
+	apiToken := c.GetHeader(AuthorizationHeader)
+	if apiToken == "" {
+		c.JSON(401, gin.H{"error": "Unauthorized"})
+		return nil, false
+	}
+
+	user, err := userRepo.GetUserByToken(c, apiToken)
+	if err != nil {
+		c.JSON(401, gin.H{"error": "Unauthorized"})
+		return nil, false
+	}
+
+	userToImpersonateStr := c.GetHeader(ImpersonationHeader)
+	if userToImpersonateStr != "" {
+		userRole, err := circleRepo.GetUserRoleInCircle(c, user.ID, user.CircleID)
+		if err != nil {
+			log.Printf("Error getting user role in circle: %s", err)
+			c.JSON(401, gin.H{"error": "Unauthorized"})
+			return nil, false
+		}
+		if *userRole != "admin" {
+			c.JSON(401, gin.H{"error": "Unauthorized"})
+			return nil, false
+		}
+
+		userIdToImpersonate, err := strconv.Atoi(userToImpersonateStr)
+		if err != nil {
+			log.Printf("Error impersonating user by id: %s", err)
+			c.JSON(401, gin.H{"error": "Unauthorized"})
+			return nil, false
+		}
+		originatingUser := user
+		user, err = userRepo.GetUser(c, userIdToImpersonate)
+		if err != nil {
+			log.Printf("Error impersonating user by username: %s", err)
+			c.JSON(401, gin.H{"error": "Unauthorized"})
+			return nil, false
+		}
+		log.Printf(
+			"User %s (%d) made an impersonated call as %s (%d)",
+			originatingUser.Username, originatingUser.ID, user.Username, user.ID,
+		)
+	}
+	return user, true
+}
+
+func TokenValidation(userRepo *uRepo.UserRepository, circleRepo *cRepo.CircleRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user, isOk := GetUserFromTokenRequest(c, userRepo, circleRepo)
+		if !isOk {
+			c.Abort()
+			return
+		}
+		c.Set(identityKey, user)
+		c.Next()
+	}
+}

--- a/internal/circle/repo/repository.go
+++ b/internal/circle/repo/repository.go
@@ -125,6 +125,14 @@ func (r *CircleRepository) GetCircleAdmins(c context.Context, circleID int) ([]*
 	return circleAdmins, nil
 }
 
+func (r *CircleRepository) GetUserRoleInCircle(c context.Context, circleID int, userId int) (*string, error) {
+	var role *string
+	if err := r.db.WithContext(c).Raw("SELECT role FROM user_circles WHERE circle_id = ? AND user_id = ?", circleID, userId).Scan(&role).Error; err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
 func (r *CircleRepository) GetDefaultCircle(c context.Context, userID int) (*cModel.Circle, error) {
 	var circle cModel.Circle
 	if err := r.db.WithContext(c).Raw("SELECT circles.* FROM circles LEFT JOIN user_circles on circles.id = user_circles.circle_id WHERE user_circles.user_id = ? AND user_circles.role = 'admin'", userID).Scan(&circle).Error; err != nil {

--- a/internal/user/repo/repository.go
+++ b/internal/user/repo/repository.go
@@ -27,6 +27,15 @@ type UserRepository struct {
 	isDonetickDotCom bool
 }
 
+func (r *UserRepository) GetUser(c context.Context, id int) (*uModel.UserDetails, error) {
+	var user *uModel.UserDetails
+
+	if err := r.db.WithContext(c).Table("users u").Select("u.*, c.webhook_url as webhook_url").Joins("left join circles c on c.id = u.circle_id").Where("u.id = ?", id).First(&user).Error; err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
 func NewUserRepository(db *gorm.DB, cfg *config.Config) *UserRepository {
 	return &UserRepository{db, cfg.IsDoneTickDotCom}
 }

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 		// fx.Provide(config.NewConfig),
 		fx.Provide(auth.NewAuthMiddleware),
 		fx.Provide(auth.NewIdentityProvider),
+		fx.Provide(auth.TokenValidation),
 		fx.Provide(resource.NewHandler),
 
 		// fx.Provide(NewBot),


### PR DESCRIPTION
This PR contains the following features:
- Added create, get, update, and delete endpoints
- Centralized eapi auth as middleware
- Added the ability for an admin's api token to impersonate a user

Notes:
There might be something I'm missing the create endpoint. Should it be a passthrough call to the version in the handler? Or alternatively should the new middleware be applied to the handler's endpoints to avoid duplication of the endpoint's logic?