### PR TITLE
Fix typo: 'Notificaiton' should be 'Notification'

### DIFF
--- a/internal/notifier/repo/repository.go
+++ b/internal/notifier/repo/repository.go
@@ -32,7 +32,7 @@ func (r *NotificationRepository) MarkNotificationsAsSent(notifications []*nModel
 	// Use the extracted IDs in the Where clause
 	return r.db.Model(&nModel.Notification{}).Where("id IN (?)", ids).Update("is_sent", true).Error
 }
-func (r *NotificationRepository) GetPendingNotificaiton(c context.Context, lookback time.Duration) ([]*nModel.NotificationDetails, error) {
+func (r *NotificationRepository) GetPendingNotification(c context.Context, lookback time.Duration) ([]*nModel.NotificationDetails, error) {
 	var notifications []*nModel.NotificationDetails
 	start := time.Now().UTC().Add(-lookback)
 	end := time.Now().UTC()

--- a/internal/notifier/scheduler.go
+++ b/internal/notifier/scheduler.go
@@ -61,7 +61,7 @@ func (s *Scheduler) cleanupSentNotifications(c context.Context) (time.Duration, 
 func (s *Scheduler) loadAndSendNotificationJob(c context.Context) (time.Duration, error) {
 	log := logging.FromContext(c)
 	startTime := time.Now()
-	getAllPendingNotifications, err := s.notificationRepo.GetPendingNotificaiton(c, time.Minute*900)
+	getAllPendingNotifications, err := s.notificationRepo.GetPendingNotification(c, time.Minute*900)
 	log.Debug("Getting pending notifications", " count ", len(getAllPendingNotifications))
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixed typo where 'Notification' was misspelled as 'Notificaiton'
- Updated function name from `GetPendingNotificaiton` to `GetPendingNotification`
- Updated corresponding function call in scheduler.go

## Changes
- `internal/notifier/repo/repository.go`: Fixed function name
- `internal/notifier/scheduler.go`: Fixed function call

Fixes #294

## Test plan
- [x] Tests pass (`go test ./...`)
- [x] No functional changes, only fixing typo in function name