### PR TITLE
Fix frequency type validation in chore API endpoints

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -211,6 +211,19 @@ func (h *Handler) createChore(c *gin.Context) {
 		choreReq.AssignedTo = choreReq.Assignees[rand.Intn(len(choreReq.Assignees))].UserID
 	}
 
+	// Validate frequency type
+	if choreReq.FrequencyType != "" && !choreReq.FrequencyType.IsValid() {
+		c.JSON(400, gin.H{
+			"error": fmt.Sprintf("Invalid frequency type: %s", choreReq.FrequencyType),
+		})
+		return
+	}
+
+	// Set default frequency type if not provided
+	if choreReq.FrequencyType == "" {
+		choreReq.FrequencyType = chModel.FrequencyTypeOnce
+	}
+
 	var dueDate *time.Time
 
 	if choreReq.DueDate != "" {
@@ -438,6 +451,15 @@ func (h *Handler) editChore(c *gin.Context) {
 		// if the assigned to field is not set, randomly assign the chore to one of the assignees
 		choreReq.AssignedTo = choreReq.Assignees[rand.Intn(len(choreReq.Assignees))].UserID
 	}
+
+	// Validate frequency type
+	if choreReq.FrequencyType != "" && !choreReq.FrequencyType.IsValid() {
+		c.JSON(400, gin.H{
+			"error": fmt.Sprintf("Invalid frequency type: %s", choreReq.FrequencyType),
+		})
+		return
+	}
+
 	oldChore, err := h.choreRepo.GetChore(c, choreReq.ID)
 
 	if err != nil {

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -31,6 +31,19 @@ const (
 	FrequencyTypeNoRepeat      FrequencyType = "no_repeat"
 )
 
+// IsValid checks if the FrequencyType is one of the predefined valid values
+func (ft FrequencyType) IsValid() bool {
+	switch ft {
+	case FrequencyTypeOnce, FrequencyTypeDaily, FrequencyTypeWeekly,
+		FrequencyTypeMonthly, FrequencyTypeYearly, FrequencyTypeAdaptive,
+		FrequencyTypeInterval, FrequencyTypeDayOfTheWeek, FrequencyTypeDayOfTheMonth,
+		FrequencyTypeTrigger, FrequencyTypeNoRepeat:
+		return true
+	default:
+		return false
+	}
+}
+
 type AssignmentStrategy string
 
 const (

--- a/internal/chore/model/model_test.go
+++ b/internal/chore/model/model_test.go
@@ -1,0 +1,107 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestFrequencyType_IsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		ft   FrequencyType
+		want bool
+	}{
+		{
+			name: "valid - once",
+			ft:   FrequencyTypeOnce,
+			want: true,
+		},
+		{
+			name: "valid - daily",
+			ft:   FrequencyTypeDaily,
+			want: true,
+		},
+		{
+			name: "valid - weekly",
+			ft:   FrequencyTypeWeekly,
+			want: true,
+		},
+		{
+			name: "valid - monthly",
+			ft:   FrequencyTypeMonthly,
+			want: true,
+		},
+		{
+			name: "valid - yearly",
+			ft:   FrequencyTypeYearly,
+			want: true,
+		},
+		{
+			name: "valid - adaptive",
+			ft:   FrequencyTypeAdaptive,
+			want: true,
+		},
+		{
+			name: "valid - interval",
+			ft:   FrequencyTypeInterval,
+			want: true,
+		},
+		{
+			name: "valid - days_of_the_week",
+			ft:   FrequencyTypeDayOfTheWeek,
+			want: true,
+		},
+		{
+			name: "valid - day_of_the_month",
+			ft:   FrequencyTypeDayOfTheMonth,
+			want: true,
+		},
+		{
+			name: "valid - trigger",
+			ft:   FrequencyTypeTrigger,
+			want: true,
+		},
+		{
+			name: "valid - no_repeat",
+			ft:   FrequencyTypeNoRepeat,
+			want: true,
+		},
+		{
+			name: "invalid - empty string",
+			ft:   "",
+			want: false,
+		},
+		{
+			name: "invalid - random string",
+			ft:   "random",
+			want: false,
+		},
+		{
+			name: "invalid - DAILY uppercase",
+			ft:   "DAILY",
+			want: false,
+		},
+		{
+			name: "invalid - Daily with capital",
+			ft:   "Daily",
+			want: false,
+		},
+		{
+			name: "invalid - one_time (not once)",
+			ft:   "one_time",
+			want: false,
+		},
+		{
+			name: "invalid - days-of-the-week (with dashes)",
+			ft:   "days-of-the-week",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ft.IsValid(); got != tt.want {
+				t.Errorf("FrequencyType.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #290 - API endpoints now validate frequency types when creating/editing chores.

## Changes
- Added `IsValid()` method to `FrequencyType` to check against valid constants
- Added validation in `createChore` and `editChore` handlers
- Set default frequency type to "once" if not provided
- Added comprehensive unit tests

## Test plan
- [x] All existing tests pass
- [x] New unit tests for `IsValid()` method pass
- [x] Invalid frequency types return 400 error with clear message