### PR TITLE
Fix panic in adaptive chore scheduling with nil PerformedAt

### DIFF
--- a/internal/chore/scheduler.go
+++ b/internal/chore/scheduler.go
@@ -168,10 +168,24 @@ func scheduleAdaptiveNextDueDate(chore *chModel.Chore, completedDate time.Time, 
 	decayFactor := 0.5 // Adjust this value to control the decay rate
 
 	for i := 0; i < len(history)-1; i++ {
+		// Skip entries with nil PerformedAt
+		if history[i].PerformedAt == nil || history[i+1].PerformedAt == nil {
+			continue
+		}
 		delay := history[i].PerformedAt.UTC().Sub(history[i+1].PerformedAt.UTC()).Seconds()
 		weight := math.Pow(decayFactor, float64(i))
 		totalDelay += delay * weight
 		totalWeight += weight
+	}
+
+	// If no valid history entries, fall back to default behavior
+	if totalWeight == 0 {
+		if chore.NextDueDate != nil {
+			diff := completedDate.UTC().Sub(chore.NextDueDate.UTC())
+			nextDueDate := completedDate.UTC().Add(diff)
+			return &nextDueDate, nil
+		}
+		return nil, nil
 	}
 
 	averageDelay := totalDelay / totalWeight

--- a/internal/chore/scheduler_adaptive_test.go
+++ b/internal/chore/scheduler_adaptive_test.go
@@ -1,0 +1,130 @@
+package chore
+
+import (
+	"testing"
+	"time"
+
+	chModel "donetick.com/core/internal/chore/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduleAdaptiveNextDueDate_WithNilPerformedAt(t *testing.T) {
+	now := time.Now().UTC()
+	
+	tests := []struct {
+		name          string
+		chore         *chModel.Chore
+		completedDate time.Time
+		history       []*chModel.ChoreHistory
+		wantNil       bool
+		wantErr       bool
+	}{
+		{
+			name: "All history entries have nil PerformedAt",
+			chore: &chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeAdaptive,
+				NextDueDate:   timePtr(now.Add(24 * time.Hour)),
+			},
+			completedDate: now,
+			history: []*chModel.ChoreHistory{
+				{PerformedAt: nil},
+				{PerformedAt: nil},
+				{PerformedAt: nil},
+			},
+			wantNil: false,
+			wantErr: false,
+		},
+		{
+			name: "Mixed nil and valid PerformedAt entries",
+			chore: &chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeAdaptive,
+			},
+			completedDate: now,
+			history: []*chModel.ChoreHistory{
+				{PerformedAt: timePtr(now.Add(-24 * time.Hour))},
+				{PerformedAt: timePtr(now.Add(-48 * time.Hour))},
+				{PerformedAt: nil},
+				{PerformedAt: timePtr(now.Add(-96 * time.Hour))},
+			},
+			wantNil: false, // Should calculate from valid consecutive entries
+			wantErr: false,
+		},
+		{
+			name: "Single history entry with nil PerformedAt",
+			chore: &chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeAdaptive,
+				NextDueDate:   timePtr(now.Add(24 * time.Hour)),
+			},
+			completedDate: now,
+			history: []*chModel.ChoreHistory{
+				{PerformedAt: nil},
+			},
+			wantNil: false,
+			wantErr: false,
+		},
+		{
+			name: "Empty history with NextDueDate",
+			chore: &chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeAdaptive,
+				NextDueDate:   timePtr(now.Add(24 * time.Hour)),
+			},
+			completedDate: now,
+			history:       []*chModel.ChoreHistory{},
+			wantNil:       false,
+			wantErr:       false,
+		},
+		{
+			name: "Empty history without NextDueDate",
+			chore: &chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeAdaptive,
+				NextDueDate:   nil,
+			},
+			completedDate: now,
+			history:       []*chModel.ChoreHistory{},
+			wantNil:       true,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := scheduleAdaptiveNextDueDate(tt.chore, tt.completedDate, tt.history)
+			
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			
+			assert.NoError(t, err)
+			
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+// Test that the fix doesn't break normal adaptive scheduling
+func TestScheduleAdaptiveNextDueDate_NormalCase(t *testing.T) {
+	now := time.Now().UTC()
+	
+	chore := &chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeAdaptive,
+	}
+	
+	history := []*chModel.ChoreHistory{
+		{PerformedAt: timePtr(now.Add(-24 * time.Hour))},
+		{PerformedAt: timePtr(now.Add(-48 * time.Hour))},
+		{PerformedAt: timePtr(now.Add(-72 * time.Hour))},
+	}
+	
+	got, err := scheduleAdaptiveNextDueDate(chore, now, history)
+	
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	// The next due date should be approximately 24 hours from now
+	// (based on the pattern in history)
+	assert.InDelta(t, now.Add(24*time.Hour).Unix(), got.Unix(), 3600) // within 1 hour
+}


### PR DESCRIPTION
## Summary
Fixes #299 - Prevents panic when completing adaptive chores that have history entries with nil PerformedAt timestamps.

## Changes
- Added nil checks in `scheduleAdaptiveNextDueDate` before accessing `PerformedAt.UTC()`
- Skip history entries with nil timestamps during calculation
- Fall back to default behavior when no valid history entries exist
- Added comprehensive test coverage for various nil scenarios

## Test Results
All tests pass:
```
=== RUN   TestScheduleAdaptiveNextDueDate_WithNilPerformedAt
--- PASS: TestScheduleAdaptiveNextDueDate_WithNilPerformedAt (0.00s)
    --- PASS: All_history_entries_have_nil_PerformedAt (0.00s)
    --- PASS: Mixed_nil_and_valid_PerformedAt_entries (0.00s)
    --- PASS: Single_history_entry_with_nil_PerformedAt (0.00s)
    --- PASS: Empty_history_with_NextDueDate (0.00s)
    --- PASS: Empty_history_without_NextDueDate (0.00s)
=== RUN   TestScheduleAdaptiveNextDueDate_NormalCase
--- PASS: TestScheduleAdaptiveNextDueDate_NormalCase (0.00s)
```

## How to Test
1. Create a chore with `frequency_type = "adaptive"`
2. Have history entries with NULL `performed_at` values
3. Try to complete the chore - it should now work without crashing

This fix ensures the application handles corrupted or incomplete history data gracefully.