### PR TITLE
add postgres dsn variable

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -20,7 +20,10 @@ func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
 	var err error
 	switch cfg.Database.Type {
 	case "postgres":
-		dsn := fmt.Sprintf("host=%s port=%v user=%s password=%s dbname=%s sslmode=disable TimeZone=Asia/Shanghai", cfg.Database.Host, cfg.Database.Port, cfg.Database.User, cfg.Database.Password, cfg.Database.Name)
+		dsn := os.Getenv("DT_POSTGRES_DSN")
+		if dsn == "" {
+			dsn = fmt.Sprintf("host=%s port=%v user=%s password=%s dbname=%s sslmode=disable TimeZone=Asia/Shanghai", cfg.Database.Host, cfg.Database.Port, cfg.Database.User, cfg.Database.Password, cfg.Database.Name)
+		}
 		for i := 0; i <= 30; i++ {
 			db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
 				Logger: logger.Default.LogMode(logger.Info),

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -355,14 +355,24 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			})
 			return
 		}
-		// Generate JWT token for Google OAuth user
+		// Generate JWT token for Google OAuth user using proper JWT middleware flow
 		c.Set("user_account", acc)
 		c.Set("auth_provider", "3rdPartyAuth")
 
-		h.jwtAuth.Authenticator(c)
-		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
+		// Use the JWT middleware's authenticator to get the user data
+		userData, err := h.jwtAuth.Authenticator(c)
 		if err != nil {
-			logger.Errorw("Unable to Generate a Token")
+			logger.Errorw("Unable to authenticate Google OAuth user", "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Unable to authenticate user",
+			})
+			return
+		}
+
+		// Generate token using the JWT middleware's token generation
+		tokenString, expire, err := h.jwtAuth.TokenGenerator(userData)
+		if err != nil {
+			logger.Errorw("Unable to Generate a Token for Google OAuth user", "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Unable to Generate a Token",
 			})
@@ -533,12 +543,24 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			return
 		}
 
-		// Generate JWT token for the user
+		// Generate JWT token for Apple user using proper JWT middleware flow
 		c.Set("user_account", acc)
-		h.jwtAuth.Authenticator(c)
-		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
+		c.Set("auth_provider", "3rdPartyAuth")
+
+		// Use the JWT middleware's authenticator to get the user data
+		userData, err := h.jwtAuth.Authenticator(c)
 		if err != nil {
-			logger.Errorw("Unable to Generate a Token for Apple user")
+			logger.Errorw("Unable to authenticate Apple user", "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Unable to authenticate user",
+			})
+			return
+		}
+
+		// Generate token using the JWT middleware's token generation
+		tokenString, expire, err := h.jwtAuth.TokenGenerator(userData)
+		if err != nil {
+			logger.Errorw("Unable to Generate a Token for Apple user", "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Unable to Generate a Token",
 			})
@@ -702,12 +724,22 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			})
 			return
 		}
-		// Generate JWT token for OAuth2 user
+		// Generate JWT token for OAuth2 user using proper JWT middleware flow
 		c.Set("user_account", acc)
 		c.Set("auth_provider", "3rdPartyAuth")
 
-		h.jwtAuth.Authenticator(c)
-		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
+		// Use the JWT middleware's authenticator to get the user data
+		userData, err := h.jwtAuth.Authenticator(c)
+		if err != nil {
+			logger.Errorw("Unable to authenticate OAuth2 user", "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Unable to authenticate user",
+			})
+			return
+		}
+
+		// Generate token using the JWT middleware's token generation
+		tokenString, expire, err := h.jwtAuth.TokenGenerator(userData)
 		if err != nil {
 			logger.Errorw("Unable to Generate a Token for OAuth2 user", "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -748,7 +748,27 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			return
 		}
 
-		logger.Infow("account.handler.thirdPartyAuthCallback (oauth2) successfully generated JWT token", "userEmail", acc.Email, "expire", expire)
+		logger.Infow("account.handler.thirdPartyAuthCallback (oauth2) successfully generated JWT token", "userEmail", acc.Email, "expire", expire, "tokenLength", len(tokenString))
+
+		// Debug: Log the actual token to see its format
+		logger.Debugw("Generated JWT token", "token", tokenString)
+
+		// Ensure the token is properly formatted
+		if tokenString == "" {
+			logger.Errorw("Generated token is empty")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Token generation failed"})
+			return
+		}
+
+		// Validate token format (should have 3 segments separated by dots)
+		parts := strings.Split(tokenString, ".")
+		if len(parts) != 3 {
+			logger.Errorw("Generated token has invalid format", "segments", len(parts), "token", tokenString)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Token format is invalid"})
+			return
+		}
+
+		logger.Infow("Token format validation passed", "segments", len(parts))
 		c.JSON(http.StatusOK, gin.H{"token": tokenString, "expire": expire})
 		return
 	}

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -359,6 +359,7 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 		c.Set("user_account", acc)
 		c.Set("auth_provider", "3rdPartyAuth")
 
+		h.jwtAuth.Authenticator(c)
 		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
 		if err != nil {
 			logger.Errorw("Unable to Generate a Token")
@@ -689,6 +690,7 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 		c.Set("user_account", acc)
 		c.Set("auth_provider", "3rdPartyAuth")
 
+		h.jwtAuth.Authenticator(c)
 		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
 		if err != nil {
 			logger.Error("Unable to Generate a Token")

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -319,6 +319,8 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 				})
 				return
 			}
+			// Set acc to the created user for consistency with the rest of the function
+			acc = &uModel.UserDetails{User: *createdUser}
 		}
 		// Check if user has MFA enabled
 		if acc.MFAEnabled {
@@ -646,6 +648,8 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 				})
 				return
 			}
+			// Set acc to the created user for consistency with the rest of the function
+			acc = &uModel.UserDetails{User: *createdUser}
 		}
 		// Check if user has MFA enabled
 		if acc.MFAEnabled {

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -355,9 +355,10 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			})
 			return
 		}
-		// use auth to generate a token for the user:
+		// Generate JWT token for Google OAuth user
 		c.Set("user_account", acc)
-		h.jwtAuth.Authenticator(c)
+		c.Set("auth_provider", "3rdPartyAuth")
+
 		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
 		if err != nil {
 			logger.Errorw("Unable to Generate a Token")
@@ -684,9 +685,10 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 			})
 			return
 		}
-		// ... (JWT generation and response)
+		// Generate JWT token for OAuth2 user
 		c.Set("user_account", acc)
-		h.jwtAuth.Authenticator(c)
+		c.Set("auth_provider", "3rdPartyAuth")
+
 		tokenString, expire, err := h.jwtAuth.TokenGenerator(acc)
 		if err != nil {
 			logger.Error("Unable to Generate a Token")


### PR DESCRIPTION
**Changes**

Added support for connecting to Postgres via the DT_POSTGRES_DSN environment variable.

If the variable is not set, the DSN is built from the existing configuration file parameters.

**Why**

Makes deployment easier by allowing the full connection string to be provided through an environment variable 
Increases flexibility — any additional connection options (e.g., SSL) can be passed directly.

**How to test**

Run the app with the environment variable set:

`export DT_POSTGRES_DSN="host=host port=5432 user=postgres password=password dbname=donetick sslmode=require TimeZone=Europe/Vilnius"`


The app should connect using this DSN, ignoring config values.

Unset the variable and verify it still connects using the config file.