### PR TITLE
Stop logging values in parameterized queries

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -37,16 +37,29 @@ func convertLogLevelToGorm(appLogLevel string) logger.LogLevel {
 func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
 	var db *gorm.DB
 	var err error
+
+	// Use GORM logger level based on application log level from config
+	gormLogLevel := convertLogLevelToGorm(cfg.Logging.Level)
+	newLogger := logger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		logger.Config{
+			SlowThreshold:             200 * time.Millisecond, // Default Logger behaviour
+			LogLevel:                  gormLogLevel,
+			IgnoreRecordNotFoundError: false,                        // Default Logger behaviour
+			Colorful:                  true,                         // Default Logger behaviour
+			ParameterizedQueries:      cfg.Logging.Level != "debug", // ParameterizedQueries=true => Don't show data in logs
+		},
+	)
+
+	gormConfig := gorm.Config{
+		Logger: newLogger,
+	}
+
 	switch cfg.Database.Type {
 	case "postgres":
 		dsn := fmt.Sprintf("host=%s port=%v user=%s password=%s dbname=%s sslmode=disable TimeZone=Asia/Shanghai", cfg.Database.Host, cfg.Database.Port, cfg.Database.User, cfg.Database.Password, cfg.Database.Name)
 		for i := 0; i <= 30; i++ {
-			// Use GORM logger level based on application log level from config
-			gormLogLevel := convertLogLevelToGorm(cfg.Logging.Level)
-
-			db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
-				Logger: logger.Default.LogMode(gormLogLevel),
-			})
+			db, err = gorm.Open(postgres.Open(dsn), &gormConfig)
 			if err == nil {
 				break
 			}
@@ -59,7 +72,7 @@ func NewDatabase(cfg *config.Config) (*gorm.DB, error) {
 		if path == "" {
 			path = "donetick.db"
 		}
-		db, err = gorm.Open(sqlite.Open(path), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(path), &gormConfig)
 
 	}
 


### PR DESCRIPTION
## Problem Description
I noticed the following log entries in my donetick logs:

```
[322.023ms] [rows:1] INSERT INTO "users" ("display_name","username","email","provider","password","circle_id","chat_id","image","timezone","parent_user_id","user_type","mfa_enabled","mfa_secret","mfa_backup_codes","mfa_recovery_codes_used","created_at","updated_at","disabled") VALUES ('test','test','test@testtest.test',0,'$2a$20$cFrQnsxH6aGhlJaik.dDgau60.2dnWdgtiM7ia9Y.OGn3F2HXxKve',0,0,'','',NULL,0,false,'','','[]','2025-10-14 09:29:49.595','2025-10-14 09:29:49.595',false) RETURNING "id"
```
This occurred with the default log level `info` running donetick v0.1.64 on an amd64 Node on a Kubernetes Cluster.

Logging these Values is not ideal for two reasons:
1. It logs PII Data which makes the log files not processable in a real prod env.
2. It leaks the (I assume hashed, definitely not plain text) Password. This is a security concern even if it is properly hashed.

## Proposed Fix
Gorm provides options to not include these Values in the logs, see [here](https://gorm.io/docs/logger.html).

The fix proposed in this PR, ensures that the values are only logged if the application log level is set to `debug`. All other gorm logger config settings are kept as the [default Logger is setting them](https://pkg.go.dev/gorm.io/gorm@v1.31.0/logger#pkg-variables). This fix tries to solve the problem with as little changes as possible. However I think it would be good to make the `ParameterizedQueries` Flag a dedicated config setting so that the user needs to set this explicitly. If this Fix/PR is accepted, I will open an Issue with a feature request to implement this.

The resulting log message reads:
```
[4.714ms] [rows:0] INSERT INTO "users" ("display_name","username","email","provider","password","circle_id","chat_id","image","timezone","parent_user_id","user_type","mfa_enabled","mfa_secret","mfa_backup_codes","mfa_recovery_codes_used","created_at","updated_at","disabled") VALUES ($1$,$2$,$3$,$4$,$5$,$6$,$7$,$8$,$9$,$10$,$11$,$12$,$13$,$14$,$15$,$16$,$17$,$18$) RETURNING "id"
```
### Additional change included in this PR:
- The DB log level conversion, log config and logger instantiation are now done outside of the loop
- The logger and config is now also set/passed to the SQLite Gorm instance.

## Testing the fix
The fix was tested on an amd64 Node in a Kubernetes Cluster. 
Steps taken to build image:
1. Modify Dockerfile for test (see below for changed file)
1. `go mod download`
2. `go build -o donetick .`
3. Build and push image:
```bash
IMAGE_NAME=$(uuidgen)
docker build -t ttl.sh/${IMAGE_NAME}:1h .
docker push ttl.sh/${IMAGE_NAME}:1h
```

Dockerfile:
```dockerfile
# Stage 1: Build the application
FROM alpine:latest AS builder

WORKDIR /usr/src/app

RUN apk --no-cache add curl jq

RUN latest_release=$(curl --silent "https://api.github.com/repos/donetick/donetick/releases/latest" | jq -r .tag_name) && \
    set -ex; \
    apkArch="$(apk --print-arch)"; \
    case "$apkArch" in \
    armhf) arch='armv6' ;; \
    armv7) arch='armv7' ;; \
    aarch64) arch='arm64' ;; \
    x86_64) arch='x86_64' ;; \
    *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
    esac; \
    curl -fL "https://github.com/donetick/donetick/releases/download/${latest_release}/donetick_Linux_$arch.tar.gz" | tar -xz -C .

# Stage 2: Create a smaller runtime image
FROM alpine:latest

# Install necessary CA certificates
RUN apk --no-cache add ca-certificates libc6-compat

# Copy the binary and config folder from the builder stage
COPY --from=builder /usr/src/app/donetick /donetick
COPY --from=builder /usr/src/app/config /config
# <<< ONLY THE FOLLOWING LINE CHANGED / WAS ADDED >>>
COPY ./donetick /donetick

# Set environment variables
ENV DT_ENV="selfhosted"

# Expose the application port
EXPOSE 2021

# Command to run the application
CMD ["/donetick"]
```

## Notes
The PR is currently pointed towards `main` I can of course make the necessary changes to merge it into `dev` if that aligns better with this projects release process.