### PR TITLE
Added at sign to username validation

### DIFF
--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -2,8 +2,8 @@ package utils
 
 import "regexp"
 
-// Username validation regex: only lowercase a-z, digits 0-9, dots, and hyphens
-var usernameRegex = regexp.MustCompile(`^[a-z0-9.-]+$`)
+// Username validation regex: only lowercase a-z, digits 0-9, dots, hyphens, and at signs
+var usernameRegex = regexp.MustCompile(`^[a-z0-9.-@]+$`)
 
 // IsValidUsername checks if username contains only lowercase letters, digits, dots, and hyphens
 func IsValidUsername(username string) bool {


### PR DESCRIPTION
The currently implemented IsValidUsername function confirms the username consists of alphanumeric, dots, and hyphens, however, the OIDC implementation sets the Username to the OIDC Provider email address, which fails username validation. This proposed change adds the at sign to the list of valid username characters.

This issue was originally brought up in #372. In the event that this is deemed undesirable, it seems we should modify the OIDC implementation so that it doesn't use the (currently invalid) username when creating accounts.