### PR TITLE
Rotate chore on a schedule

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -2910,6 +2910,7 @@ func (h *Handler) updateTimer(c *gin.Context) {
 // shouldRotate determines if enough completions have occurred to trigger assignee rotation.
 // It counts consecutive completions by the current assignee and compares against RotateEvery threshold.
 // Only completed chores count toward the rotation threshold (skipped chores don't count).
+// Note: This is called BEFORE the current completion is saved to history, so we add 1 to account for it.
 func shouldRotate(chore *chModel.Chore, history []*chModel.ChoreHistory) bool {
 	if chore.AssignedTo == nil || chore.RotateEvery == nil || *chore.RotateEvery <= 0 {
 		return true // Always rotate if no threshold set or no current assignee
@@ -2933,9 +2934,9 @@ func shouldRotate(chore *chModel.Chore, history []*chModel.ChoreHistory) bool {
 		}
 	}
 
-	// Rotate if we've reached or exceeded the threshold
-	// Note: we use >= because the current completion (about to happen) will be the Nth one
-	return consecutiveCount >= *chore.RotateEvery
+	// Add 1 to account for the current completion that's about to happen
+	// Rotate if we've reached the threshold
+	return (consecutiveCount + 1) >= *chore.RotateEvery
 }
 
 func checkNextAssignee(chore *chModel.Chore, choresHistory []*chModel.ChoreHistory, performerID int) (int, error) {

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -252,6 +252,7 @@ func (h *Handler) createChore(c *gin.Context) {
 		FrequencyMetadataV2:    choreReq.FrequencyMetadata,
 		NextDueDate:            dueDate,
 		AssignStrategy:         choreReq.AssignStrategy,
+		RotateEvery:            choreReq.RotateEvery,
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
 		UpdatedBy:              currentUser.ID,
@@ -530,6 +531,7 @@ func (h *Handler) editChore(c *gin.Context) {
 		// Assignees:         &assignees,
 		NextDueDate:            dueDate,
 		AssignStrategy:         choreReq.AssignStrategy,
+		RotateEvery:            choreReq.RotateEvery,
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
 		IsActive:               choreReq.IsActive,
@@ -2905,6 +2907,37 @@ func (h *Handler) updateTimer(c *gin.Context) {
 	})
 }
 
+// shouldRotate determines if enough completions have occurred to trigger assignee rotation.
+// It counts consecutive completions by the current assignee and compares against RotateEvery threshold.
+// Only completed chores count toward the rotation threshold (skipped chores don't count).
+func shouldRotate(chore *chModel.Chore, history []*chModel.ChoreHistory) bool {
+	if chore.AssignedTo == nil || chore.RotateEvery == nil || *chore.RotateEvery <= 0 {
+		return true // Always rotate if no threshold set or no current assignee
+	}
+
+	// Count consecutive completions by current assignee since last rotation
+	// History is ordered most recent first
+	consecutiveCount := 0
+	for _, h := range history {
+		// Only count completed chores (not skipped, pending, etc.)
+		if h.Status != chModel.ChoreHistoryStatusCompleted {
+			continue
+		}
+		// Check if this completion was by the current assignee
+		if h.AssignedTo != nil && *h.AssignedTo == *chore.AssignedTo {
+			consecutiveCount++
+		} else {
+			// Different assignee found, stop counting
+			// This means we've reached the point of last rotation
+			break
+		}
+	}
+
+	// Rotate if we've reached or exceeded the threshold
+	// Note: we use >= because the current completion (about to happen) will be the Nth one
+	return consecutiveCount >= *chore.RotateEvery
+}
+
 func checkNextAssignee(chore *chModel.Chore, choresHistory []*chModel.ChoreHistory, performerID int) (int, error) {
 	// copy the history to avoid modifying the original:
 	history := make([]*chModel.ChoreHistory, len(choresHistory))
@@ -2920,6 +2953,18 @@ func checkNextAssignee(chore *chModel.Chore, choresHistory []*chModel.ChoreHisto
 		history = append(history, &chModel.ChoreHistory{
 			AssignedTo: &performerID,
 		})
+	}
+
+	// Check if we should rotate based on RotateEvery threshold
+	// This applies to strategies that actually rotate (not keep_last_assigned or no_assignee)
+	if chore.RotateEvery != nil && *chore.RotateEvery > 0 {
+		if !shouldRotate(chore, history) {
+			// Keep current assignee - not enough completions yet
+			if chore.AssignedTo != nil {
+				return *chore.AssignedTo, nil
+			}
+			return performerID, nil
+		}
 	}
 
 	switch chore.AssignStrategy {

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -55,6 +55,7 @@ type Chore struct {
 	AssignedTo             *int                  `json:"assignedTo" gorm:"column:assigned_to"`                              // Who the chore is assigned to
 	Assignees              []ChoreAssignees      `json:"assignees" gorm:"foreignkey:ChoreID;references:ID"`                 // Assignees of the chore
 	AssignStrategy         AssignmentStrategy    `json:"assignStrategy" gorm:"column:assign_strategy"`                      // How the chore is assigned
+	RotateEvery            *int                  `json:"rotateEvery,omitempty" gorm:"column:rotate_every"`                   // Number of completions before rotating assignee (nil or 0 = rotate every time)
 	IsActive               bool                  `json:"isActive" gorm:"column:is_active"`                                  // Whether the chore is active
 	Notification           bool                  `json:"notification" gorm:"column:notification"`                           // Whether the chore has notification
 	NotificationMetadata   *string               `json:"-" gorm:"column:notification_meta"`                                 // TODO: Clean up after v0.1.39
@@ -216,6 +217,7 @@ type ChoreReq struct {
 	DueDate              string                `json:"dueDate"`
 	Assignees            []ChoreAssignees      `json:"assignees"`
 	AssignStrategy       AssignmentStrategy    `json:"assignStrategy" binding:"required"`
+	RotateEvery          *int                  `json:"rotateEvery,omitempty"`
 	AssignedTo           *int                  `json:"assignedTo"`
 	IsRolling            bool                  `json:"isRolling"`
 	IsActive             bool                  `json:"isActive"`

--- a/internal/database/migrations/20260107_add_rotate_every_to_chores.sql
+++ b/internal/database/migrations/20260107_add_rotate_every_to_chores.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+-- Add rotate_every column to chores table for scheduled rotation
+-- This column specifies how many completions should occur before rotating the assignee
+-- NULL or 0 means rotate on every completion (default behavior)
+ALTER TABLE chores ADD COLUMN IF NOT EXISTS rotate_every INTEGER DEFAULT NULL;
+
+-- +migrate Down
+ALTER TABLE chores DROP COLUMN IF EXISTS rotate_every;


### PR DESCRIPTION
This feature adds the ability to rotate a chore on a schedule that is not every completion. It fits the use case where there is a daily chore, but rotation among kids is weekly. There’s an associated FE change I’ll submit as well