### PR TITLE
eAPI chore endpoints now accept subTasks

### DIFF
--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -207,6 +207,7 @@ type ChoreLiteReq struct {
 	ID          int     `json:"id"`
 	DueDate     string  `json:"dueDate"`
 	CreatedBy   *int    `json:"createdBy"`
+	SubTasks    *[]stModel.SubTask `json:"subTasks,omitempty"`
 }
 
 type ChoreReq struct {


### PR DESCRIPTION
## Context / problem
I’m using the eAPI (`eapi/v1/chore`) from an automation workflow (n8n) that sends a task with a bullet list and expects those bullets to become subtasks. The workflow was already building a `subTasks` array correctly, but Donetick was dropping it. The reason is simple: the eAPI binds `ChoreLiteReq`, which didn’t include `subTasks`, so the payload was accepted but the subtasks were ignored.

## What I changed
- Allow `subTasks` in `ChoreLiteReq` so the eAPI accepts the field.
- On create, persist subtasks via `SubTasksRepository.UpdateSubtask(...)` and then refetch the chore.
- On update, diff existing vs requested subtasks and update via `UpdateSubtask(...)` (same logic as the UI handler).

## Files touched
- `internal/chore/model/model.go`
- `internal/chore/api.go`

## Testing
I ran the tests and nothing fails now, also I used this version on my instance and the subtask now generates successfully via eapi.

## Notes
- This keeps the eAPI auth and response format unchanged.
- Subtask payload matches existing `SubTask` model (`name`, optional `orderId`, `parentId`, etc.).