### PR TITLE
More fields in EAPI chore endpoint

### DIFF
--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -202,13 +202,19 @@ type ChoreLabels struct {
 	Label   Label
 }
 type ChoreLiteReq struct {
-	Name        string           `json:"name" binding:"required"`
-	Description *string          `json:"description"`
-	ID          int              `json:"id"`
-	DueDate     string           `json:"dueDate"`
-	CreatedBy   *int             `json:"createdBy"`
-	Assignees   []ChoreAssignees `json:"assignees"`
-	AssignedTo  *int             `json:"assignedTo"`
+	Name              string              `json:"name" binding:"required"`
+	Description       *string             `json:"description"`
+	ID                int                 `json:"id"`
+	DueDate           string              `json:"dueDate"`
+	CreatedBy         *int                `json:"createdBy"`
+	Assignees         []ChoreAssignees    `json:"assignees"`
+	AssignedTo        *int                `json:"assignedTo"`
+	FrequencyType     FrequencyType       `json:"frequencyType"`
+	Frequency         int                 `json:"frequency"`
+	FrequencyMetadata *FrequencyMetadata  `json:"frequencyMetadata"`
+	IsRolling         bool                `json:"isRolling"`
+	AssignStrategy    *AssignmentStrategy `json:"assignStrategy"`
+	Points            *int                `json:"points"`
 }
 
 type ChoreReq struct {


### PR DESCRIPTION
Hi! My use case for Donetick has a service that needs to create full chores (with assignees) via a webhook-style interaction coming from a family dashboard in the kitchen (which has more than just Donetick scope). The dashboard authenticates via PAT for a service account, which conflicted mostly with the creator=assignee logic and was the primary source of my family’s complaints, but in my testing I realized a few other fields would be painful too. 

So, this PR adds the necessary scope to EAPI to meet my use case, while maintaining backwards compat with previous functionality. 