### PR TITLE
Add circleID to label creation and update

### DIFF
--- a/internal/label/handler.go
+++ b/internal/label/handler.go
@@ -74,6 +74,7 @@ func (h *Handler) createLabel(c *gin.Context) {
 		Name:      req.Name,
 		Color:     req.Color,
 		CreatedBy: currentUser.ID,
+		CircleID:  &currentUser.CircleID,
 	}
 	if err := h.lRepo.CreateLabels(c, []*lModel.Label{label}); err != nil {
 		c.JSON(500, gin.H{
@@ -105,9 +106,10 @@ func (h *Handler) updateLabel(c *gin.Context) {
 	}
 
 	label := &lModel.Label{
-		Name:  req.Name,
-		Color: req.Color,
-		ID:    req.ID,
+		Name:     req.Name,
+		Color:    req.Color,
+		ID:       req.ID,
+		CircleID: &currentUser.CircleID,
 	}
 	if err := h.lRepo.UpdateLabel(c, currentUser.ID, label); err != nil {
 		c.JSON(500, gin.H{


### PR DESCRIPTION
the "role" could not be parsed on backend because the model mapping wasn't present for circleID

Related issue: https://github.com/donetick/donetick/issues/321