### PR TITLE
config: default RateLimit/RatePeriod to match selfhosted.yaml values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,8 +107,8 @@ type JwtConfig struct {
 
 type ServerConfig struct {
 	Port             int           `mapstructure:"port" yaml:"port"`
-	RatePeriod       time.Duration `mapstructure:"rate_period" yaml:"rate_period"`
-	RateLimit        int           `mapstructure:"rate_limit" yaml:"rate_limit"`
+	RatePeriod       time.Duration `mapstructure:"rate_period" yaml:"rate_period" default:"60s"`
+	RateLimit        int           `mapstructure:"rate_limit" yaml:"rate_limit" default:"300"`
 	ReadTimeout      time.Duration `mapstructure:"read_timeout" yaml:"read_timeout"`
 	WriteTimeout     time.Duration `mapstructure:"write_timeout" yaml:"write_timeout"`
 	WebhookTimeout   time.Duration `mapstructure:"webhook_timeout" yaml:"webhook_timeout"`


### PR DESCRIPTION
When Donetick starts without a config file, viper leaves `RateLimit` and `RatePeriod` as zero. `ulule/limiter` treats a zero rate as immediately exhausted, returning 429 on every request, including signup on a fresh install.

Adds `default` struct tags to both fields, using the values already defined in `config/selfhosted.yaml` (`rate_limit: 300`, `rate_period: 60s`). The existing `defaults.SetDefaults()` call in `NewConfig()` picks them up when no config file is present.

Fixes #558