### PR TITLE
Fix: Cancel notifications for completed, deleted, or edited tasks

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -971,10 +971,15 @@ func (h *Handler) updateAssignee(c *gin.Context) {
 		return
 	}
 
+	// Get updated chore and regenerate notifications
+	updatedChore, err := h.choreRepo.GetChore(c, id, currentUser.ID)
+	if err == nil {
+		h.nPlanner.GenerateNotifications(c, updatedChore)
+	}
+
 	// Broadcast real-time assignee update event
 	if h.realTimeService != nil {
-		updatedChore, err := h.choreRepo.GetChore(c, id, currentUser.ID)
-		if err == nil {
+		if updatedChore != nil {
 			broadcaster := h.realTimeService.GetEventBroadcaster()
 			changes := map[string]interface{}{
 				"assignedTo": assigneeReq.Assignee,
@@ -1435,6 +1440,7 @@ func (h *Handler) skipChore(c *gin.Context) {
 		})
 		return
 	}
+	h.nPlanner.GenerateNotifications(c, updatedChore)
 	h.eventProducer.ChoreSkipped(c, effectiveUser.WebhookURL, updatedChore, &effectiveUser.User)
 
 	// Broadcast real-time chore skip event
@@ -1549,10 +1555,15 @@ func (h *Handler) updateDueDate(c *gin.Context) {
 		return
 	}
 
+	// Get updated chore and regenerate notifications
+	updatedChore, err := h.choreRepo.GetChore(c, chore.ID, currentUser.ID)
+	if err == nil {
+		h.nPlanner.GenerateNotifications(c, updatedChore)
+	}
+
 	// Broadcast real-time due date update event
 	if h.realTimeService != nil {
-		updatedChore, err := h.choreRepo.GetChore(c, chore.ID, currentUser.ID)
-		if err == nil {
+		if updatedChore != nil {
 			broadcaster := h.realTimeService.GetEventBroadcaster()
 			changes := map[string]interface{}{
 				"nextDueDate": dueDate,
@@ -1609,6 +1620,9 @@ func (h *Handler) archiveChore(c *gin.Context) {
 		})
 		return
 	}
+
+	// Delete all notifications for the archived chore
+	h.nRepo.DeleteAllChoreNotifications(id)
 
 	// Broadcast real-time chore archive event
 	if h.realTimeService != nil {
@@ -1671,10 +1685,15 @@ func (h *Handler) UnarchiveChore(c *gin.Context) {
 		return
 	}
 
+	// Get updated chore and regenerate notifications
+	updatedChore, err := h.choreRepo.GetChore(c, id, currentUser.ID)
+	if err == nil {
+		h.nPlanner.GenerateNotifications(c, updatedChore)
+	}
+
 	// Broadcast real-time chore unarchive event
 	if h.realTimeService != nil {
-		updatedChore, err := h.choreRepo.GetChore(c, id, currentUser.ID)
-		if err == nil {
+		if updatedChore != nil {
 			broadcaster := h.realTimeService.GetEventBroadcaster()
 			changes := map[string]interface{}{
 				"archived":  false,


### PR DESCRIPTION
## Description

Fixes #503

This PR ensures that scheduled notifications are properly canceled or regenerated whenever a task state changes. Previously, the notification scheduling logic was not being updated in several key handlers, which could result in users receiving notifications about tasks that are no longer active or have been modified.

## Changes Made

1. **skipChore**: Added `GenerateNotifications` call to regenerate notifications when a chore is skipped (due date changes)
2. **updateDueDate**: Added `GenerateNotifications` call to regenerate notifications when the due date is manually updated
3. **updateAssignee**: Added `GenerateNotifications` call to regenerate notifications when the assigned user changes (notifications are sent to the assigned user)
4. **archiveChore**: Added `DeleteAllChoreNotifications` call to cancel all notifications for archived chores
5. **UnarchiveChore**: Added `GenerateNotifications` call to regenerate notifications when a chore is unarchived

## Technical Details

The `GenerateNotifications` function already handles deleting old notifications before creating new ones (via `DeleteAllChoreNotifications`), so calling it ensures that:
- Old notifications are removed
- New notifications are created based on the updated chore state
- Notifications are only scheduled for future dates

The following handlers were already correctly handling notifications:
- `completeChore` ✓
- `editChore` ✓
- `deleteChore` ✓
- `approveChore` ✓

## Testing

This change ensures that:
- When a user skips a chore, old notifications are canceled and new ones are scheduled for the new due date
- When a user updates the due date, notifications are rescheduled accordingly
- When an assignee is changed, notifications are sent to the correct user
- When a chore is archived, all pending notifications are canceled
- When a chore is unarchived, notifications are regenerated

## Related Issues

Closes #503