### PR TITLE
feat: add PUID/PGID support to Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,18 +28,24 @@ FROM alpine:latest
 # Install necessary CA certificates
 RUN apk --no-cache add ca-certificates libc6-compat
 
-# Install timezone package
-RUN apk --no-cache add tzdata
+# Install timezone package and su-exec for stepping down from root
+RUN apk --no-cache add tzdata su-exec
 
 # Copy the binary and config folder from the builder stage
 COPY --from=builder /usr/src/app/donetick /donetick
 COPY --from=builder /usr/src/app/config /config
+COPY entrypoint.sh /entrypoint.sh
 
 # Set environment variables
 ENV DT_ENV="selfhosted"
 
+# Default PUID and PGID values (can be overridden at runtime). Use these to
+# ensure the files on the volumes have the permissions you need.
+ENV PUID=1000
+ENV PGID=1000
+
 # Expose the application port
 EXPOSE 2021
 
-# Command to run the application
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/donetick"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,8 +9,8 @@ COPY config/selfhosted.yaml config/local.yaml ./config/
 # Stage 2: Create a smaller runtime image
 FROM alpine:latest
 
-# Install timezone package
-RUN apk --no-cache add tzdata
+# Install timezone package and su-exec for stepping down from root
+RUN apk --no-cache add tzdata su-exec
 
 # Install necessary CA certificates
 RUN apk --no-cache add ca-certificates libc6-compat
@@ -18,12 +18,18 @@ RUN apk --no-cache add ca-certificates libc6-compat
 # Copy the binary and config folder from the builder stage
 COPY --from=builder /usr/src/app/donetick /donetick
 COPY --from=builder /usr/src/app/config /config
+COPY entrypoint.sh /entrypoint.sh
 
 # Set environment variables
 ENV DT_ENV="selfhosted"
 
+# Default PUID and PGID values (can be overridden at runtime). Use these to
+# ensure the files on the volumes have the permissions you need.
+ENV PUID=1000
+ENV PGID=1000
+
 # Expose the application port
 EXPOSE 2021
 
-# Command to run the application
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/donetick"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# <img src="assets/icon.png" alt="drawing" width="45"/>Donetick 
+# <img src="assets/icon.png" alt="drawing" width="45"/>Donetick
 
 
 
@@ -27,7 +27,7 @@ Donetick is an open-source, user-friendly app designed to help you organize task
 
 **Natural Language Task Creation**: Describe what you need to do in plain English. Donetick automatically extracts dates, times, and recurrence patterns from phrases like “Change water filter every 6 months” or “Take the trash out every Monday and Tuesday at 6:15 pm.”
 
-**Task Advanced Scheduling**: 
+**Task Advanced Scheduling**:
 - Supports flexible scheduling: daily, weekly, monthly, yearly, specific months, specific days of the week, or even adaptive scheduling — where Donetick learns from historical completions to suggest due dates automatically.
 - Due Date vs Completion Date Based Recurrence: Choose whether recurring tasks should be scheduled from the previous due date (ideal for a consistent cadence) or from the actual completion date (useful when tasks are often delayed).
 - Assignee Rotation: Automatically rotate task assignments based on who has completed the fewest tasks, randomly, or in turns(round-robin) order.
@@ -61,7 +61,7 @@ Donetick is an open-source, user-friendly app designed to help you organize task
 
 **Realtime Sync**: Enable realtime sync to instantly reflect task changes across all connected devices and users.  whether you are adding, editing, or completing a task. It reflects immediately on enabled devices!
 
-**Offline Support**: You can access donetick if you lose connection and navigate some areas, but this is very limited functionality at the moment. 
+**Offline Support**: You can access donetick if you lose connection and navigate some areas, but this is very limited functionality at the moment.
 
 **Multi-Platform Notifications**: Get reminders through the mobile app (we have an alpha iOS app on TestFlight, and the Android APK is available in releases), as well as via Telegram, Discord, or Pushover.
 
@@ -76,9 +76,9 @@ Donetick is an open-source, user-friendly app designed to help you organize task
 
 ## Quick Start
 > [!NOTE]
-> Before running the application, ensure you have a valid `selfhosted.yaml` configuration file. 
+> Before running the application, ensure you have a valid `selfhosted.yaml` configuration file.
 > If you don't have one, create a `selfhosted.yaml` file based on the example provided [here](https://github.com/donetick/donetick/blob/main/config/selfhosted.yaml).
-> Place the `selfhosted.yaml` file in the `/config` directory within your application's root directory 
+> Place the `selfhosted.yaml` file in the `/config` directory within your application's root directory
 
 
 
@@ -121,13 +121,15 @@ services:
       - DT_ENV=selfhosted
       - DT_SQLITE_PATH=/donetick-data/donetick.db
       - TZ=Etc/UTC
+      - PUID=1000
+      - PGID=1000
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:2021/api/v1/health || exit 1
       start_period: 1m
       timeout: 5s
       interval: 1m
       retries: 3
-      
+  
 ```
 
 
@@ -139,7 +141,7 @@ services:
    ```
 3. **Run Donetick:**
    ```bash
-   DT_ENV=selfhosted ./donetick 
+   DT_ENV=selfhosted ./donetick
    ```
 
 ---

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+set -o pipefail
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if [ "$(id -u)" = "0" ]; then
+    addgroup -g "$PGID" -S donetick 2>/dev/null || true
+    adduser -u "$PUID" -G donetick -S -H -D donetick 2>/dev/null || true
+
+    mkdir -p /donetick-data /config
+    chown -R "$PUID:$PGID" /donetick-data /config
+
+    exec su-exec donetick "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
When Docker creates mounted volumes, files are owned by root by
default, causing permission mismatches on the host. PUID/PGID
lets users map the container process to their host UID/GID so
volume-mounted files (e.g. the SQLite database) have correct
ownership without manual chown on the host.

The entrypoint starts as root to create a matching user/group,
fix data/config directory ownership, then drops privileges via
su-exec before running the application.

PUID/PGID default to 1000 in both the Dockerfile ENV and the
entrypoint script. The ENV makes the defaults discoverable via
docker inspect (plus graphical Docker tools often display such
ENV variables, thereby showing to the user that setting them is
possible). The entrypoint fallback ensures robustness if the
ENV is unset.