### PR TITLE
fix: set DT_SQLITE_PATH default in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=builder /usr/src/app/config /config
 
 # Set environment variables
 ENV DT_ENV="selfhosted"
+ENV DT_SQLITE_PATH="/donetick-data/donetick.db"
 
 # Expose the application port
 EXPOSE 2021

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,6 +21,7 @@ COPY --from=builder /usr/src/app/config /config
 
 # Set environment variables
 ENV DT_ENV="selfhosted"
+ENV DT_SQLITE_PATH="/donetick-data/donetick.db"
 
 # Expose the application port
 EXPOSE 2021


### PR DESCRIPTION
Without this, a bare 'docker run' without explicitly passing
DT_SQLITE_PATH writes the SQLite DB to /donetick.db (the CWD),
which is lost on container recreation.