### PR TITLE
fix: include validation details in API error responses

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -41,7 +41,7 @@ func (h *AuthHandler) RefreshTokenHandler(c *gin.Context) {
 		var req RefreshRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "No refresh token provided",
+				"error": "Invalid request: " + err.Error(),
 			})
 			return
 		}
@@ -141,7 +141,7 @@ func (h *AuthHandler) EnhancedLoginHandler(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&loginReq); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid request format",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -258,7 +258,7 @@ func (h *Handler) createChore(c *gin.Context) {
 	if err := c.ShouldBindJSON(&choreReq); err != nil {
 		logger.Error("Invalid request body", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request format",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -438,7 +438,7 @@ func (h *Handler) editChore(c *gin.Context) {
 	if err := c.ShouldBindJSON(&choreReq); err != nil {
 		logger.Error("Invalid request body", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request format",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -928,7 +928,7 @@ func (h *Handler) updateAssignee(c *gin.Context) {
 	if err := c.ShouldBindJSON(&assigneeReq); err != nil {
 		logging.FromContext(c).Error("Operation failed", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -1511,7 +1511,7 @@ func (h *Handler) updateDueDate(c *gin.Context) {
 	if err := c.ShouldBindJSON(&dueDateReq); err != nil {
 		logging.FromContext(c).Error("Operation failed", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -2129,7 +2129,7 @@ func (h *Handler) ModifyHistory(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logging.FromContext(c).Error("Operation failed", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -2224,7 +2224,7 @@ func (h *Handler) updatePriority(c *gin.Context) {
 	if err := c.ShouldBindJSON(&priorityReq); err != nil {
 		logging.FromContext(c).Error("Operation failed", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -2485,7 +2485,7 @@ func (h *Handler) UpdateSubtaskCompletedAt(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logging.FromContext(c).Error("Operation failed", "error", err)
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -2701,7 +2701,7 @@ func (h *Handler) UpdateTimeSession(c *gin.Context) {
 	var req UpdateTimeSessionReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Invalid request body",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -3233,7 +3233,7 @@ func (h *Handler) updateChoreStatus(c *gin.Context) {
 	var statusReq StatusUpdateReq
 	if err := c.ShouldBindJSON(&statusReq); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -3337,7 +3337,7 @@ func (h *Handler) updateTimer(c *gin.Context) {
 	var timerReq TimerUpdateReq
 	if err := c.ShouldBindJSON(&timerReq); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -3584,7 +3584,7 @@ func (h *Handler) sendNudgeNotification(c *gin.Context) {
 	var req NudgeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		log.Error("Invalid request payload", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
 		return
 	}
 

--- a/internal/label/handler.go
+++ b/internal/label/handler.go
@@ -65,7 +65,7 @@ func (h *Handler) createLabel(c *gin.Context) {
 	var req LabelReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Error binding label",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -100,7 +100,7 @@ func (h *Handler) updateLabel(c *gin.Context) {
 	var req UpdateLabelReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Error binding label",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -232,7 +232,7 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 		if err := c.ShouldBindJSON(&body); err != nil {
 			logger.Errorw("account.handler.thirdPartyAuthCallback failed to bind", "err", err)
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid request",
+				"error": "Invalid request: " + err.Error(),
 			})
 			return
 		}
@@ -408,7 +408,7 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 		if err := c.ShouldBindJSON(&body); err != nil {
 			logger.Errorw("account.handler.thirdPartyAuthCallback (apple) failed to bind", "err", err)
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid request",
+				"error": "Invalid request: " + err.Error(),
 			})
 			return
 		}
@@ -566,7 +566,7 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 		var req Request
 		if err := c.ShouldBindJSON(&req); err != nil {
 			logger.Errorw("account.handler.thirdPartyAuthCallback (oauth2) failed to bind request", "err", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
 			return
 		}
 
@@ -727,7 +727,7 @@ func (h *Handler) resetPassword(c *gin.Context) {
 	var req ResetPasswordReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -798,7 +798,7 @@ func (h *Handler) updateUserPassword(c *gin.Context) {
 	if err := c.ShouldBindJSON(&body); err != nil {
 		logger.Errorw("user.handler.resetAccountPassword failed to bind", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 
@@ -840,7 +840,7 @@ func (h *Handler) UpdateUserDetails(c *gin.Context) {
 	var req UpdateUserReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -886,7 +886,7 @@ func (h *Handler) CreateLongLivedToken(c *gin.Context) {
 	}
 	var req TokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
 		return
 	}
 
@@ -995,7 +995,7 @@ func (h *Handler) UpdateNotificationTarget(c *gin.Context) {
 
 	var req Request
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
 		return
 	}
 	if req.Type == nModel.NotificationPlatformNone {
@@ -1037,7 +1037,7 @@ func (h *Handler) updateUserPasswordLoggedInOnly(c *gin.Context) {
 	if err := c.ShouldBindJSON(&body); err != nil {
 		logger.Errorw("user.handler.resetAccountPassword failed to bind", "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid request",
+			"error": "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -1080,7 +1080,7 @@ func (h *Handler) setWebhook(c *gin.Context) {
 
 	var req Request
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
 		return
 	}
 


### PR DESCRIPTION
## Summary

All `ShouldBindJSON` error handlers now return the actual validation error instead of generic "Invalid request" messages.

## Why this matters

When updating a chore via the API, a missing required field like "name" returns "Invalid request" with no hint about which field is wrong (#326). The `err.Error()` from Gin's validator already contains field-level details like "Key: 'ChoreReq.Name' Error:Field validation for 'Name' failed on the 'required' tag" - it just wasn't being returned.

## Changes

25 error handlers updated across 4 files:
- `internal/chore/handler.go` (11 handlers)
- `internal/user/handler.go` (10 handlers)
- `internal/label/handler.go` (2 handlers)
- `internal/auth/handler.go` (2 handlers)

Each changed from generic text to `"Invalid request: " + err.Error()`. Handlers that already included `err.Error()` or intentionally ignore the error were left untouched.

## Testing

`go build ./...` passes. No behavioral change beyond adding error detail text to existing 400 responses.

Fixes #326

This contribution was developed with AI assistance (Claude Code).