### PR TITLE
fix: expose is_user_creation_disabled in /resource endpoint

### DIFF
--- a/internal/resource/handler.go
+++ b/internal/resource/handler.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Resource struct {
-	Idp        identityProvider `json:"identity_provider" binding:"omitempty"`
-	MinVersion string           `json:"min_version" binding:"omitempty"`
-	APIVersion string           `json:"api_version" binding:"omitempty"`
-	APICommit  string           `json:"api_commit" binding:"omitempty"`
+	Idp                    identityProvider `json:"identity_provider" binding:"omitempty"`
+	MinVersion             string           `json:"min_version" binding:"omitempty"`
+	APIVersion             string           `json:"api_version" binding:"omitempty"`
+	APICommit              string           `json:"api_commit" binding:"omitempty"`
+	IsUserCreationDisabled bool             `json:"is_user_creation_disabled"`
 }
 type identityProvider struct {
 	Auth_url  string `json:"auth_url" binding:"omitempty"`
@@ -36,9 +37,10 @@ func (h *Handler) getResource(c *gin.Context) {
 			Client_ID: h.config.OAuth2Config.ClientID,
 			Name:      h.config.OAuth2Config.Name,
 		},
-		MinVersion: h.config.MinVersion,
-		APIVersion: h.config.Info.Version,
-		APICommit:  h.config.Info.Commit,
+		MinVersion:             h.config.MinVersion,
+		APIVersion:             h.config.Info.Version,
+		APICommit:              h.config.Info.Commit,
+		IsUserCreationDisabled: h.config.IsUserCreationDisabled,
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds the `is_user_creation_disabled` field to the `/api/v1/resource` endpoint response so the frontend can conditionally hide the "Create new account" button when user signup is disabled.

## Changes

- Added `IsUserCreationDisabled` field to the `Resource` struct with JSON tag `is_user_creation_disabled`
- Pass `h.config.IsUserCreationDisabled` to the response in `getResource`

## Related

- Fixes #602 (backend part)
- Frontend PR: donetick/frontend#76 (to be created)

## How it works

When `is_user_creation_disabled` is set to `true` in the config (or via `DONETICK_DISABLE_SIGNUP=true` env var), the `/resource` endpoint now returns `"is_user_creation_disabled": true` in its JSON response. The frontend uses this to hide the signup button.