### PR TITLE
fix: HTML-escape display name in UpdateUserDetails

### DIFF
--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -846,7 +846,7 @@ func (h *Handler) UpdateUserDetails(c *gin.Context) {
 	}
 	// update non-nil fields:
 	if req.DisplayName != nil {
-		user.DisplayName = *req.DisplayName
+		user.DisplayName = html.EscapeString(*req.DisplayName)
 	}
 	if req.ChatID != nil {
 		user.ChatID = *req.ChatID


### PR DESCRIPTION
## Summary

Adds `html.EscapeString` to the display name in the `UpdateUserDetails` handler to match the existing signup behavior, preventing potential XSS issues and ensuring consistent data storage.

## Problem

During signup, the display name is HTML-escaped (`html.EscapeString`), but when updating user details via `PUT /api/v1/users`, it is not. This inconsistency could allow unescaped HTML/script content to be stored via profile updates.

## Changes

- Added `html.EscapeString(*req.DisplayName)` in `UpdateUserDetails` (line 849 of `internal/user/handler.go`)

## Fixes

Fixes #303