### PR TITLE
fix: add cache headers for static assets with cache busting

### DIFF
--- a/frontend/handler.go
+++ b/frontend/handler.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"strings"
 
 	"donetick.com/core/config"
 	"github.com/gin-gonic/gin"
@@ -44,6 +45,12 @@ func staticMiddleware(root string) gin.HandlerFunc {
 		if err != nil {
 			c.Next()
 			return
+		}
+		// Cache-busted assets (filenames contain content hashes) can be
+		// cached indefinitely. Other files like index.html must not be
+		// cached so that updates are picked up immediately.
+		if strings.HasPrefix(c.Request.URL.Path, "/assets/") {
+			c.Header("Cache-Control", "public, max-age=31536000, immutable")
 		}
 		fileServer.ServeHTTP(c.Writer, c.Request)
 


### PR DESCRIPTION
## Summary

Adds `Cache-Control: public, max-age=31536000, immutable` header for static files served from the `/assets/` directory. These files already use content-hash-based filenames (e.g., `index-DuC9e_gl.css`, `web-BsMh9bqo.js`) for cache busting, so they can be safely cached indefinitely by browsers.

## Changes

- Added a `Cache-Control` header in `staticMiddleware` (`frontend/handler.go`) for requests matching the `/assets/` path prefix
- Files like `index.html` are not affected (no caching header is set for them)

## Benefits

- Reduces unnecessary network requests for static assets that haven't changed
- Improves page load performance for returning users
- Leverages the existing cache-busting filenames from the frontend build

Fixes #265