### PR TITLE
Add iCal calendar feed for chores

### DIFF
--- a/internal/calendar/handler.go
+++ b/internal/calendar/handler.go
@@ -1,0 +1,347 @@
+package calendar
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"donetick.com/core/config"
+	auth "donetick.com/core/internal/auth"
+	chModel "donetick.com/core/internal/chore/model"
+	chRepo "donetick.com/core/internal/chore/repo"
+	uRepo "donetick.com/core/internal/user/repo"
+	"donetick.com/core/logging"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	calendarTokenPrefix = "dtcal"
+	calendarProdID      = "-//Donetick//Chores Calendar//EN"
+)
+
+// Handler handles iCal calendar endpoints
+type Handler struct {
+	choreRepo *chRepo.ChoreRepository
+	userRepo  *uRepo.UserRepository
+	secret    string
+}
+
+// NewHandler creates a new calendar handler
+func NewHandler(cr *chRepo.ChoreRepository, ur *uRepo.UserRepository, cfg *config.Config) *Handler {
+	return &Handler{
+		choreRepo: cr,
+		userRepo:  ur,
+		secret:    cfg.Jwt.Secret,
+	}
+}
+
+// generateCalendarToken creates an HMAC-signed token for a user's calendar URL.
+func (h *Handler) generateCalendarToken(userID int) string {
+	payload := fmt.Sprintf("%s:%d", calendarTokenPrefix, userID)
+	mac := hmac.New(sha256.New, []byte(h.secret))
+	mac.Write([]byte(payload))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("%d-%s", userID, sig)
+}
+
+// parseCalendarToken validates a calendar token and returns the user ID.
+func (h *Handler) parseCalendarToken(token string) (int, error) {
+	parts := strings.SplitN(token, "-", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("invalid token format")
+	}
+
+	userID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid user ID in token")
+	}
+
+	expectedToken := h.generateCalendarToken(userID)
+	if !hmac.Equal([]byte(token), []byte(expectedToken)) {
+		return 0, fmt.Errorf("invalid token signature")
+	}
+
+	return userID, nil
+}
+
+// GetCalendarURL godoc
+//
+//	@Summary		Get calendar subscription URL
+//	@Description	Returns a personal iCal calendar subscription URL for the current user
+//	@Tags			chores
+//	@Produce		json
+//	@Security		JWTKeyAuth
+//	@Security		APIKeyAuth
+//	@Success		200	{object}	map[string]string	"url: calendar subscription URL"
+//	@Failure		401	{object}	map[string]string	"error: Authentication failed"
+//	@Router			/chores/calendar/url [get]
+func (h *Handler) GetCalendarURL(c *gin.Context) {
+	logger := logging.FromContext(c)
+	currentUser, ok := auth.CurrentUser(c)
+	if !ok {
+		logger.Error("Failed to get current user from authentication context")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication failed"})
+		return
+	}
+
+	token := h.generateCalendarToken(currentUser.ID)
+
+	scheme := "https"
+	if c.Request.TLS == nil {
+		if fwdProto := c.GetHeader("X-Forwarded-Proto"); fwdProto != "" {
+			scheme = fwdProto
+		} else {
+			scheme = "http"
+		}
+	}
+	host := c.Request.Host
+	calendarURL := fmt.Sprintf("%s://%s/api/v1/chores/calendar/%s.ics", scheme, host, token)
+
+	c.JSON(http.StatusOK, gin.H{
+		"url": calendarURL,
+	})
+}
+
+// ServeCalendar godoc
+//
+//	@Summary		Serve iCal calendar feed
+//	@Description	Serves an iCal (.ics) calendar file containing the user's chores. Authenticated via HMAC token in URL.
+//	@Tags			chores
+//	@Produce		text/calendar
+//	@Param			token	path		string	true	"Calendar token (obtained from /chores/calendar/url)"
+//	@Success		200		{string}	string	"iCal calendar data"
+//	@Failure		403		{string}	string	"Invalid calendar token"
+//	@Failure		500		{string}	string	"Failed to generate calendar"
+//	@Router			/chores/calendar/{token} [get]
+func (h *Handler) ServeCalendar(c *gin.Context) {
+	logger := logging.FromContext(c)
+
+	rawToken := c.Param("token")
+	rawToken = strings.TrimSuffix(rawToken, ".ics")
+
+	userID, err := h.parseCalendarToken(rawToken)
+	if err != nil {
+		logger.Error("Invalid calendar token", "error", err)
+		c.String(http.StatusForbidden, "Invalid calendar token")
+		return
+	}
+
+	user, err := h.userRepo.GetUserByID(c.Request.Context(), userID)
+	if err != nil || user.Disabled {
+		logger.Error("Calendar user not found or disabled", "userID", userID, "error", err)
+		c.String(http.StatusForbidden, "Invalid calendar token")
+		return
+	}
+
+	chores, err := h.choreRepo.GetChores(c, user.CircleID, userID, false)
+	if err != nil {
+		logger.Error("Failed to retrieve chores for calendar", "error", err, "userID", userID)
+		c.String(http.StatusInternalServerError, "Failed to generate calendar")
+		return
+	}
+
+	ical := buildICalFeed(chores, user.DisplayName, user.Timezone)
+
+	c.Header("Content-Type", "text/calendar; charset=utf-8")
+	c.Header("Content-Disposition", "attachment; filename=\"donetick-chores.ics\"")
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+	c.String(http.StatusOK, ical)
+}
+
+// buildICalFeed generates a full VCALENDAR string from a list of chores.
+func buildICalFeed(chores []*chModel.Chore, calendarName string, userTimezone string) string {
+	var b strings.Builder
+
+	b.WriteString("BEGIN:VCALENDAR\r\n")
+	b.WriteString("VERSION:2.0\r\n")
+	b.WriteString(foldLine(fmt.Sprintf("PRODID:%s", calendarProdID)))
+	b.WriteString(foldLine(fmt.Sprintf("X-WR-CALNAME:Donetick - %s", escapeICalText(calendarName))))
+	b.WriteString("METHOD:PUBLISH\r\n")
+	b.WriteString("CALSCALE:GREGORIAN\r\n")
+
+	if userTimezone != "" {
+		b.WriteString(foldLine(fmt.Sprintf("X-WR-TIMEZONE:%s", userTimezone)))
+	}
+
+	now := time.Now().UTC()
+	dtstamp := now.Format("20060102T150405Z")
+
+	for _, ch := range chores {
+		if ch.NextDueDate == nil {
+			continue
+		}
+
+		b.WriteString("BEGIN:VEVENT\r\n")
+
+		uid := fmt.Sprintf("chore-%d@donetick", ch.ID)
+		b.WriteString(foldLine(fmt.Sprintf("UID:%s", uid)))
+		b.WriteString(fmt.Sprintf("DTSTAMP:%s\r\n", dtstamp))
+
+		dtstart := ch.NextDueDate.UTC().Format("20060102T150405Z")
+		b.WriteString(fmt.Sprintf("DTSTART:%s\r\n", dtstart))
+
+		// Use completion window (hours) as event duration, default 1 hour
+		duration := time.Hour
+		if ch.CompletionWindow != nil && *ch.CompletionWindow > 0 {
+			duration = time.Duration(*ch.CompletionWindow) * time.Hour
+		}
+		dtend := ch.NextDueDate.Add(duration).UTC().Format("20060102T150405Z")
+		b.WriteString(fmt.Sprintf("DTEND:%s\r\n", dtend))
+
+		b.WriteString(foldLine(fmt.Sprintf("SUMMARY:%s", escapeICalText(ch.Name))))
+
+		desc := buildChoreDescription(ch)
+		if desc != "" {
+			b.WriteString(foldLine(fmt.Sprintf("DESCRIPTION:%s", escapeICalText(desc))))
+		}
+
+		icalPriority := mapPriority(ch.Priority)
+		if icalPriority > 0 {
+			b.WriteString(fmt.Sprintf("PRIORITY:%d\r\n", icalPriority))
+		}
+
+		switch ch.Status {
+		case chModel.ChoreStatusInProgress:
+			b.WriteString("STATUS:IN-PROCESS\r\n")
+		default:
+			b.WriteString("STATUS:NEEDS-ACTION\r\n")
+		}
+
+		b.WriteString(fmt.Sprintf("LAST-MODIFIED:%s\r\n", ch.UpdatedAt.UTC().Format("20060102T150405Z")))
+		b.WriteString("END:VEVENT\r\n")
+	}
+
+	b.WriteString("END:VCALENDAR\r\n")
+	return b.String()
+}
+
+// buildChoreDescription creates a plain-text description for the calendar event.
+func buildChoreDescription(ch *chModel.Chore) string {
+	var parts []string
+
+	if ch.Description != nil && *ch.Description != "" {
+		parts = append(parts, stripHTMLTags(*ch.Description))
+	}
+
+	if ch.FrequencyType != "" && ch.FrequencyType != chModel.FrequencyTypeOnce {
+		parts = append(parts, fmt.Sprintf("Repeats: %s", ch.FrequencyType))
+	}
+
+	if ch.Points != nil && *ch.Points > 0 {
+		parts = append(parts, fmt.Sprintf("Points: %d", *ch.Points))
+	}
+
+	pName := priorityName(ch.Priority)
+	if pName != "" {
+		parts = append(parts, fmt.Sprintf("Priority: %s", pName))
+	}
+
+	return strings.Join(parts, "\\n")
+}
+
+// escapeICalText escapes special characters per RFC 5545.
+func escapeICalText(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, ";", "\\;")
+	s = strings.ReplaceAll(s, ",", "\\,")
+	s = strings.ReplaceAll(s, "\r\n", "\\n")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+// foldLine implements RFC 5545 line folding (content lines must be <= 75 octets).
+func foldLine(line string) string {
+	const maxLen = 75
+	line = strings.TrimRight(line, "\r\n")
+
+	if len(line) <= maxLen {
+		return line + "\r\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(line[:maxLen])
+	b.WriteString("\r\n")
+	remaining := line[maxLen:]
+
+	for len(remaining) > 0 {
+		chunkLen := 74 // continuation lines start with a space, leaving 74 for content
+		if chunkLen > len(remaining) {
+			chunkLen = len(remaining)
+		}
+		b.WriteByte(' ')
+		b.WriteString(remaining[:chunkLen])
+		b.WriteString("\r\n")
+		remaining = remaining[chunkLen:]
+	}
+
+	return b.String()
+}
+
+// mapPriority converts Donetick priority (0-4) to iCal priority (1-9).
+func mapPriority(p int) int {
+	switch p {
+	case 4:
+		return 1 // urgent -> highest
+	case 3:
+		return 3 // high
+	case 2:
+		return 5 // medium
+	case 1:
+		return 7 // low
+	default:
+		return 0 // undefined
+	}
+}
+
+// priorityName returns a human-readable priority name.
+func priorityName(p int) string {
+	switch p {
+	case 4:
+		return "Urgent"
+	case 3:
+		return "High"
+	case 2:
+		return "Medium"
+	case 1:
+		return "Low"
+	default:
+		return ""
+	}
+}
+
+// stripHTMLTags removes HTML tags from a string for plain-text output.
+func stripHTMLTags(s string) string {
+	var b strings.Builder
+	inTag := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+		case !inTag:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// Routes registers calendar-specific routes
+func Routes(router *gin.Engine, h *Handler, multiAuthMiddleware *auth.MultiAuthMiddleware) {
+	// Authenticated endpoint to get the user's personal calendar URL
+	calRoutes := router.Group("api/v1/chores/calendar")
+	calRoutes.Use(multiAuthMiddleware.MiddlewareFunc())
+	{
+		calRoutes.GET("/url", h.GetCalendarURL)
+	}
+
+	// Public endpoint (token-authenticated via HMAC) to serve the .ics file
+	// Calendar apps cannot send JWT headers, so this uses token-in-URL auth
+	router.GET("api/v1/chores/calendar/:token", h.ServeCalendar)
+}

--- a/internal/calendar/handler_test.go
+++ b/internal/calendar/handler_test.go
@@ -1,0 +1,589 @@
+package calendar
+
+import (
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+    "time"
+
+    chModel "donetick.com/core/internal/chore/model"
+    "github.com/gin-gonic/gin"
+)
+
+func TestGenerateAndParseCalendarToken(t *testing.T) {
+    h := &Handler{secret: "test-secret-key"}
+
+    userID := 42
+    token := h.generateCalendarToken(userID)
+
+    // Token should contain the user ID
+    if !strings.HasPrefix(token, "42-") {
+        t.Errorf("token should start with '42-', got %q", token)
+    }
+
+    // Parse should return the same user ID
+    parsedID, err := h.parseCalendarToken(token)
+    if err != nil {
+        t.Fatalf("parseCalendarToken returned error: %v", err)
+    }
+    if parsedID != userID {
+        t.Errorf("expected userID %d, got %d", userID, parsedID)
+    }
+}
+
+func TestParseCalendarToken_InvalidFormat(t *testing.T) {
+    h := &Handler{secret: "test-secret-key"}
+
+    tests := []struct {
+        name  string
+        token string
+    }{
+        {"empty", ""},
+        {"no dash", "abc123"},
+        {"non-numeric user ID", "abc-def"},
+        {"wrong signature", "42-invalidsignature"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            _, err := h.parseCalendarToken(tt.token)
+            if err == nil {
+                t.Error("expected error, got nil")
+            }
+        })
+    }
+}
+
+func TestParseCalendarToken_WrongSecret(t *testing.T) {
+    h1 := &Handler{secret: "secret-one"}
+    h2 := &Handler{secret: "secret-two"}
+
+    token := h1.generateCalendarToken(42)
+
+    _, err := h2.parseCalendarToken(token)
+    if err == nil {
+        t.Error("expected error when parsing token with different secret, got nil")
+    }
+}
+
+func TestParseCalendarToken_DifferentUserIDs(t *testing.T) {
+    h := &Handler{secret: "test-secret-key"}
+
+    token1 := h.generateCalendarToken(1)
+    token2 := h.generateCalendarToken(2)
+
+    if token1 == token2 {
+        t.Error("tokens for different users should be different")
+    }
+
+    // Try to tamper: take signature from user 1 and put user 2's ID
+    parts := strings.SplitN(token1, "-", 2)
+    tampered := fmt.Sprintf("2-%s", parts[1])
+
+    _, err := h.parseCalendarToken(tampered)
+    if err == nil {
+        t.Error("expected error for tampered token, got nil")
+    }
+}
+
+func TestEscapeICalText(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    string
+        expected string
+    }{
+        {"plain text", "hello world", "hello world"},
+        {"semicolon", "a;b", "a\\;b"},
+        {"comma", "a,b", "a\\,b"},
+        {"backslash", "a\\b", "a\\\\b"},
+        {"newline", "a\nb", "a\\nb"},
+        {"crlf", "a\r\nb", "a\\nb"},
+        {"carriage return", "a\rb", "ab"},
+        {"combined", "hello; world,\nfoo\\bar", "hello\\; world\\,\\nfoo\\\\bar"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := escapeICalText(tt.input)
+            if result != tt.expected {
+                t.Errorf("escapeICalText(%q) = %q, want %q", tt.input, result, tt.expected)
+            }
+        })
+    }
+}
+
+func TestFoldLine(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    string
+        maxLines int // 0 means don't check line count
+    }{
+        {"short line", "SHORT:value", 1},
+        {"exactly 75", "DESCRIPTION:" + strings.Repeat("x", 63), 1},
+        {"76 chars needs folding", "DESCRIPTION:" + strings.Repeat("x", 64), 2},
+        {"very long line", "DESCRIPTION:" + strings.Repeat("x", 200), 0},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := foldLine(tt.input)
+
+            // Must end with \r\n
+            if !strings.HasSuffix(result, "\r\n") {
+                t.Error("folded line must end with CRLF")
+            }
+
+            // Split into lines and verify each
+            lines := strings.Split(strings.TrimSuffix(result, "\r\n"), "\r\n")
+
+            if tt.maxLines > 0 && len(lines) != tt.maxLines {
+                t.Errorf("expected %d lines, got %d: %q", tt.maxLines, len(lines), result)
+            }
+
+            // First line must be <= 75 octets
+            if len(lines[0]) > 75 {
+                t.Errorf("first line is %d octets, max 75: %q", len(lines[0]), lines[0])
+            }
+
+            // Continuation lines must start with space and be <= 75 octets total
+            for i := 1; i < len(lines); i++ {
+                if lines[i][0] != ' ' {
+                    t.Errorf("continuation line %d must start with space: %q", i, lines[i])
+                }
+                if len(lines[i]) > 75 {
+                    t.Errorf("continuation line %d is %d octets, max 75: %q", i, len(lines[i]), lines[i])
+                }
+            }
+        })
+    }
+}
+
+func TestFoldLine_Roundtrip(t *testing.T) {
+    // Verify that unfolding a folded line gives back the original
+    original := "DESCRIPTION:" + strings.Repeat("abcdefghij", 20)
+    folded := foldLine(original)
+
+    // Unfold per RFC 5545: remove CRLF followed by a single space
+    unfolded := strings.ReplaceAll(folded, "\r\n ", "")
+    unfolded = strings.TrimSuffix(unfolded, "\r\n")
+
+    if unfolded != original {
+        t.Errorf("roundtrip failed:\n  original: %q\n  unfolded: %q", original, unfolded)
+    }
+}
+
+func TestMapPriority(t *testing.T) {
+    tests := []struct {
+        input    int
+        expected int
+    }{
+        {0, 0},
+        {1, 7},
+        {2, 5},
+        {3, 3},
+        {4, 1},
+        {5, 0}, // unknown
+    }
+
+    for _, tt := range tests {
+        t.Run(fmt.Sprintf("priority_%d", tt.input), func(t *testing.T) {
+            result := mapPriority(tt.input)
+            if result != tt.expected {
+                t.Errorf("mapPriority(%d) = %d, want %d", tt.input, result, tt.expected)
+            }
+        })
+    }
+}
+
+func TestPriorityName(t *testing.T) {
+    tests := []struct {
+        input    int
+        expected string
+    }{
+        {0, ""},
+        {1, "Low"},
+        {2, "Medium"},
+        {3, "High"},
+        {4, "Urgent"},
+        {5, ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(fmt.Sprintf("priority_%d", tt.input), func(t *testing.T) {
+            result := priorityName(tt.input)
+            if result != tt.expected {
+                t.Errorf("priorityName(%d) = %q, want %q", tt.input, result, tt.expected)
+            }
+        })
+    }
+}
+
+func TestStripHTMLTags(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    string
+        expected string
+    }{
+        {"no tags", "hello world", "hello world"},
+        {"simple tag", "<b>bold</b>", "bold"},
+        {"nested tags", "<div><p>text</p></div>", "text"},
+        {"self closing", "before<br/>after", "beforeafter"},
+        {"with attributes", `<a href="url">link</a>`, "link"},
+        {"empty", "", ""},
+        {"only tags", "<div></div>", ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := stripHTMLTags(tt.input)
+            if result != tt.expected {
+                t.Errorf("stripHTMLTags(%q) = %q, want %q", tt.input, result, tt.expected)
+            }
+        })
+    }
+}
+
+func TestBuildICalFeed_Empty(t *testing.T) {
+    result := buildICalFeed([]*chModel.Chore{}, "Test User", "America/New_York")
+
+    if !strings.Contains(result, "BEGIN:VCALENDAR") {
+        t.Error("missing BEGIN:VCALENDAR")
+    }
+    if !strings.Contains(result, "END:VCALENDAR") {
+        t.Error("missing END:VCALENDAR")
+    }
+    if !strings.Contains(result, "VERSION:2.0") {
+        t.Error("missing VERSION:2.0")
+    }
+    if !strings.Contains(result, "PRODID:") {
+        t.Error("missing PRODID")
+    }
+    if strings.Contains(result, "BEGIN:VEVENT") {
+        t.Error("should not contain VEVENT for empty chore list")
+    }
+    if !strings.Contains(result, "X-WR-CALNAME:Donetick - Test User") {
+        t.Error("missing calendar name")
+    }
+    if !strings.Contains(result, "X-WR-TIMEZONE:America/New_York") {
+        t.Error("missing timezone")
+    }
+}
+
+func TestBuildICalFeed_SkipsChoresWithoutDueDate(t *testing.T) {
+    chores := []*chModel.Chore{
+        {
+            ID:          1,
+            Name:        "No Due Date",
+            NextDueDate: nil,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    if strings.Contains(result, "BEGIN:VEVENT") {
+        t.Error("should not contain VEVENT for chore without due date")
+    }
+}
+
+func TestBuildICalFeed_BasicChore(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+    updatedAt := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+    desc := "Clean the kitchen"
+    points := 5
+
+    chores := []*chModel.Chore{
+        {
+            ID:          42,
+            Name:        "Kitchen Cleaning",
+            Description: &desc,
+            NextDueDate: &dueDate,
+            Priority:    3,
+            Points:      &points,
+            Status:      0, // active/default status
+        },
+    }
+    // Set UpdatedAt manually (it's embedded in gorm.Model)
+    chores[0].UpdatedAt = updatedAt
+
+    result := buildICalFeed(chores, "Test User", "UTC")
+
+    checks := []struct {
+        name     string
+        contains string
+    }{
+        {"VEVENT start", "BEGIN:VEVENT"},
+        {"VEVENT end", "END:VEVENT"},
+        {"UID", "UID:chore-42@donetick"},
+        {"DTSTART", "DTSTART:20250615T100000Z"},
+        {"SUMMARY", "SUMMARY:Kitchen Cleaning"},
+        {"PRIORITY", "PRIORITY:3"},
+        {"STATUS", "STATUS:NEEDS-ACTION"},
+        {"LAST-MODIFIED", "LAST-MODIFIED:20250601T120000Z"},
+    }
+
+    for _, check := range checks {
+        t.Run(check.name, func(t *testing.T) {
+            if !strings.Contains(result, check.contains) {
+                t.Errorf("missing %q in output:\n%s", check.contains, result)
+            }
+        })
+    }
+
+    // Check description contains the text and metadata
+    if !strings.Contains(result, "DESCRIPTION:") {
+        t.Error("missing DESCRIPTION")
+    }
+    if !strings.Contains(result, "Clean the kitchen") {
+        t.Error("missing description text")
+    }
+}
+
+func TestBuildICalFeed_CompletionWindow(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+    window := 3 // 3 hours
+
+    chores := []*chModel.Chore{
+        {
+            ID:               1,
+            Name:             "Test",
+            NextDueDate:      &dueDate,
+            CompletionWindow: &window,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    // DTEND should be 3 hours after DTSTART
+    if !strings.Contains(result, "DTEND:20250615T130000Z") {
+        t.Errorf("expected DTEND 3 hours after start, got:\n%s", result)
+    }
+}
+
+func TestBuildICalFeed_DefaultDuration(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+    chores := []*chModel.Chore{
+        {
+            ID:          1,
+            Name:        "Test",
+            NextDueDate: &dueDate,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    // Default duration is 1 hour
+    if !strings.Contains(result, "DTEND:20250615T110000Z") {
+        t.Errorf("expected DTEND 1 hour after start (default), got:\n%s", result)
+    }
+}
+
+func TestBuildICalFeed_InProgressStatus(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+    chores := []*chModel.Chore{
+        {
+            ID:          1,
+            Name:        "Test",
+            NextDueDate: &dueDate,
+            Status:      chModel.ChoreStatusInProgress,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    if !strings.Contains(result, "STATUS:IN-PROCESS") {
+        t.Errorf("expected IN-PROCESS status, got:\n%s", result)
+    }
+}
+
+func TestBuildICalFeed_SpecialCharactersInName(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+    chores := []*chModel.Chore{
+        {
+            ID:          1,
+            Name:        "Buy groceries; milk, eggs, bread",
+            NextDueDate: &dueDate,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    if !strings.Contains(result, "SUMMARY:Buy groceries\\; milk\\, eggs\\, bread") {
+        t.Errorf("special characters not properly escaped in:\n%s", result)
+    }
+}
+
+func TestBuildICalFeed_HTMLDescription(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+    desc := "<p>Clean the <b>kitchen</b> thoroughly</p>"
+
+    chores := []*chModel.Chore{
+        {
+            ID:          1,
+            Name:        "Test",
+            Description: &desc,
+            NextDueDate: &dueDate,
+        },
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    if strings.Contains(result, "<p>") || strings.Contains(result, "<b>") {
+        t.Errorf("HTML tags should be stripped from description:\n%s", result)
+    }
+    if !strings.Contains(result, "Clean the kitchen thoroughly") {
+        t.Errorf("description text missing after HTML stripping:\n%s", result)
+    }
+}
+
+func TestBuildICalFeed_MultipleChores(t *testing.T) {
+    due1 := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+    due2 := time.Date(2025, 6, 16, 14, 0, 0, 0, time.UTC)
+
+    chores := []*chModel.Chore{
+        {ID: 1, Name: "Chore One", NextDueDate: &due1},
+        {ID: 2, Name: "Chore Two", NextDueDate: &due2},
+        {ID: 3, Name: "No Date", NextDueDate: nil}, // should be skipped
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    eventCount := strings.Count(result, "BEGIN:VEVENT")
+    if eventCount != 2 {
+        t.Errorf("expected 2 VEVENTs, got %d", eventCount)
+    }
+
+    if !strings.Contains(result, "chore-1@donetick") {
+        t.Error("missing UID for chore 1")
+    }
+    if !strings.Contains(result, "chore-2@donetick") {
+        t.Error("missing UID for chore 2")
+    }
+    if strings.Contains(result, "chore-3@donetick") {
+        t.Error("chore 3 (no due date) should not be included")
+    }
+}
+
+func TestBuildICalFeed_CRLFLineEndings(t *testing.T) {
+    dueDate := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+    chores := []*chModel.Chore{
+        {ID: 1, Name: "Test", NextDueDate: &dueDate},
+    }
+
+    result := buildICalFeed(chores, "Test", "")
+
+    // Every line should end with \r\n (RFC 5545 requirement)
+    lines := strings.Split(result, "\r\n")
+    // The last element after split will be empty string (after final \r\n)
+    if lines[len(lines)-1] != "" {
+        t.Error("file should end with CRLF")
+    }
+
+    // Verify no bare \n exists (that isn't part of \r\n)
+    withoutCRLF := strings.ReplaceAll(result, "\r\n", "")
+    if strings.Contains(withoutCRLF, "\n") {
+        t.Error("found bare LF not part of CRLF")
+    }
+}
+
+func TestBuildChoreDescription_AllFields(t *testing.T) {
+    desc := "Do the thing"
+    points := 10
+
+    ch := &chModel.Chore{
+        Description:   &desc,
+        FrequencyType: chModel.FrequencyTypeDaily,
+        Points:        &points,
+        Priority:      3,
+    }
+
+    result := buildChoreDescription(ch)
+
+    if !strings.Contains(result, "Do the thing") {
+        t.Error("missing description text")
+    }
+    if !strings.Contains(result, "Repeats: daily") {
+        t.Error("missing frequency info")
+    }
+    if !strings.Contains(result, "Points: 10") {
+        t.Error("missing points")
+    }
+    if !strings.Contains(result, "Priority: High") {
+        t.Error("missing priority")
+    }
+}
+
+func TestBuildChoreDescription_OnceFrequencyOmitted(t *testing.T) {
+    ch := &chModel.Chore{
+        FrequencyType: chModel.FrequencyTypeOnce,
+    }
+
+    result := buildChoreDescription(ch)
+
+    if strings.Contains(result, "Repeats") {
+        t.Error("once frequency should not show 'Repeats'")
+    }
+}
+
+func TestBuildChoreDescription_Empty(t *testing.T) {
+    ch := &chModel.Chore{}
+
+    result := buildChoreDescription(ch)
+
+    if result != "" {
+        t.Errorf("expected empty description, got %q", result)
+    }
+}
+
+func TestBuildChoreDescription_ZeroPoints(t *testing.T) {
+    points := 0
+    ch := &chModel.Chore{
+        Points: &points,
+    }
+
+    result := buildChoreDescription(ch)
+
+    if strings.Contains(result, "Points") {
+        t.Error("zero points should not be included")
+    }
+}
+
+func TestServeCalendar_InvalidToken(t *testing.T) {
+    h := &Handler{secret: "test-secret"}
+
+    w := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(w)
+    c.Params = gin.Params{{Key: "token", Value: "invalid-token.ics"}}
+    c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/chores/calendar/invalid-token.ics", nil)
+
+    h.ServeCalendar(c)
+
+    if w.Code != http.StatusForbidden {
+        t.Errorf("expected status 403, got %d", w.Code)
+    }
+}
+
+func TestServeCalendar_TamperedToken(t *testing.T) {
+    h := &Handler{secret: "test-secret"}
+
+    // Generate valid token for user 1, then change user ID to 2
+    token := h.generateCalendarToken(1)
+    parts := strings.SplitN(token, "-", 2)
+    tampered := fmt.Sprintf("2-%s.ics", parts[1])
+
+    w := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(w)
+    c.Params = gin.Params{{Key: "token", Value: tampered}}
+    c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/chores/calendar/"+tampered, nil)
+
+    h.ServeCalendar(c)
+
+    if w.Code != http.StatusForbidden {
+        t.Errorf("expected status 403, got %d", w.Code)
+    }
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"donetick.com/core/frontend"
 	auth "donetick.com/core/internal/auth"
 	"donetick.com/core/internal/auth/apple"
+	"donetick.com/core/internal/calendar"
 	"donetick.com/core/internal/chore"
 	chRepo "donetick.com/core/internal/chore/repo"
 	"donetick.com/core/internal/circle"
@@ -85,6 +86,7 @@ func main() {
 		fx.Provide(database.NewDatabase),
 		fx.Provide(chRepo.NewChoreRepository),
 		fx.Provide(chore.NewHandler),
+		fx.Provide(calendar.NewHandler),
 		fx.Provide(uRepo.NewUserRepository),
 		fx.Provide(user.NewDeletionService),
 		fx.Provide(user.NewHandler),
@@ -187,6 +189,7 @@ func main() {
 		// fx.Invoke(RunApp),
 		fx.Invoke(
 			chore.Routes,
+			calendar.Routes,
 			chore.APIs,
 			user.Routes,
 			circle.Routes,


### PR DESCRIPTION
This adds the ability for users to subscribe to their chores as a standard iCal calendar feed, so they can see upcoming chores directly in Google Calendar, Apple Calendar, Outlook, or any other calendar app that supports .ics subscriptions.

There are two new endpoints:
- `GET /api/v1/chores/calendar/url` - an authenticated endpoint that returns a personal calendar subscription URL for the current user. The URL contains a HMAC-signed token so it doesn't require JWT headers (since calendar apps can't send those).
- `GET /api/v1/chores/calendar/:token` - a public endpoint that serves the actual .ics file. The token in the URL is validated via HMAC to identify and authenticate the user.

Each chore with a due date becomes a VEVENT in the feed. The event duration uses the chore's completion window if set, otherwise defaults to one hour. Priority values are mapped to the iCal priority scale, descriptions have HTML stripped out for plain-text display, and the output follows RFC 5545 formatting (CRLF line endings, line folding at 75 octets, proper text
escaping).

The calendar name shows up as "Donetick - {display name}" and respects the user's timezone setting. Disabled users get rejected even if they have a valid token.
