### PR TITLE
fix(oidc): honor preferred_username claim on OAuth2 signup

### DIFF
--- a/internal/auth/identity_provider.go
+++ b/internal/auth/identity_provider.go
@@ -14,6 +14,7 @@ import (
 
 type IdentityProviderUserInfo struct {
 	Identifier  string
+	Username    string
 	DisplayName string
 	Email       string
 	Picture     string
@@ -107,6 +108,9 @@ func (i *IdentityProvider) GetUserInfo(ctx context.Context, accessToken string) 
 	userInfo := IdentityProviderUserInfo{}
 	if val, ok := claims["sub"]; ok {
 		userInfo.Identifier = val.(string)
+	}
+	if val, ok := claims["preferred_username"]; ok {
+		userInfo.Username, _ = val.(string)
 	}
 	if val, ok := claims["name"]; ok {
 		userInfo.DisplayName = val.(string)

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -612,8 +612,15 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Password encoding failed"})
 				return
 			}
+			// Prefer the OIDC `preferred_username` claim for the username;
+			// fall back to email so the unique column stays non-empty when
+			// the provider doesn't supply one.
+			username := claims.Username
+			if username == "" {
+				username = claims.Email
+			}
 			account := &uModel.User{
-				Username:    claims.Email,
+				Username:    username,
 				Email:       claims.Email,
 				Password:    encodedPassword,
 				Image:       claims.Picture,


### PR DESCRIPTION
Read the standard OIDC `preferred_username` claim from the userinfo endpoint and use it as the account's username when creating a new OAuth2 user. Fall back to the email address when the IdP doesn't supply one so the unique column stays non-empty.

Previously the OIDC callback always stored `claims.Email` in the `username` column, meaning users saw their email address as their identifier even when their IdP exposed a proper handle.