### PR TITLE
feat(storage): add storage.path_style option for S3 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,12 @@ type StorageConfig struct {
 	MaxUserStorage int    `mapstructure:"max_user_storage" yaml:"max_user_storage"`
 	MaxFileSize    int64  `mapstructure:"max_file_size" yaml:"max_file_size"`
 	PublicHost     string `mapstructure:"public_host" yaml:"public_host"`
+	// PathStyle forces path-style S3 addressing (endpoint/bucket/key)
+	// instead of the default virtual-hosted style (bucket.endpoint/key).
+	// Required for S3-compatible backends like MinIO that don't expose
+	// a DNS wildcard at `*.<endpoint-host>`, as well as for plain HTTP
+	// endpoints without matching TLS wildcard certs.
+	PathStyle bool `mapstructure:"path_style" yaml:"path_style"`
 }
 type DonetickCloudConfig struct {
 	GoogleClientID        string `mapstructure:"google_client_id" yaml:"google_client_id"`

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,12 @@ type StorageConfig struct {
 	// (e.g. via a bucket policy). Intended for self-hosted deployments
 	// that don't want the 7-day presigned URL ceiling.
 	PublicRead bool `mapstructure:"public_read" yaml:"public_read"`
+	// PathStyle forces path-style S3 addressing (endpoint/bucket/key)
+	// instead of the default virtual-hosted style (bucket.endpoint/key).
+	// Required for S3-compatible backends like MinIO that don't expose
+	// a DNS wildcard at `*.<endpoint-host>`, as well as for plain HTTP
+	// endpoints without matching TLS wildcard certs.
+	PathStyle bool `mapstructure:"path_style" yaml:"path_style"`
 }
 type DonetickCloudConfig struct {
 	GoogleClientID        string `mapstructure:"google_client_id" yaml:"google_client_id"`

--- a/internal/storage/storage_s3.go
+++ b/internal/storage/storage_s3.go
@@ -34,6 +34,7 @@ func NewS3Storage(config *config.Config) (*S3Storage, error) {
 			config.Storage.SecretKey,
 			"",
 		),
+		S3ForcePathStyle: aws.Bool(config.Storage.PathStyle),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/storage/storage_s3.go
+++ b/internal/storage/storage_s3.go
@@ -35,6 +35,7 @@ func NewS3Storage(config *config.Config) (*S3Storage, error) {
 			config.Storage.SecretKey,
 			"",
 		),
+		S3ForcePathStyle: aws.Bool(config.Storage.PathStyle),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
By default aws-sdk-go uses virtual-hosted-style addressing, which produces URLs like `https://<bucket>.<endpoint-host>/<key>`. For self-hosted S3-compatible backends (MinIO, Garage, SeaweedFS, …) this typically fails because:

- there is no DNS wildcard at `*.<endpoint-host>`, so the bucket- prefixed hostname doesn't resolve; and
- even if it does resolve, the TLS certificate on the endpoint usually doesn't cover the bucket-prefixed subdomain.

Add a new boolean `storage.path_style` which, when true, sets `aws.Config.S3ForcePathStyle` so requests go to
`https://<endpoint-host>/<bucket>/<key>` instead. The default is false so the existing virtual-hosted behavior is unchanged.