### PR TITLE
Single-circle instance mode and OIDC group role mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,43 @@ services:
 
 ---
 
+## Single-Circle Instance Mode & OIDC Group-Based Roles
+
+These features are designed for self-hosted single-household deployments where circle management should be hidden from end users and roles should be managed via your OIDC identity provider.
+
+### Environment Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `DT_SINGLE_CIRCLE_INSTANCE` | bool | `false` | Hides circle-management UI and disables join/leave/delete-member/accept-request endpoints. New OIDC users are added to a shared household circle (ID 1) instead of getting a personal circle. |
+| `DT_OAUTH2_ADMIN_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `admin` role. |
+| `DT_OAUTH2_MANAGER_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `manager` role. |
+
+### Role Resolution Rules
+
+Role sync runs **on every OIDC login** (not just first-time user creation), so your IdP is the source of truth. Removing someone from the admin group in your IdP will demote them on their next login.
+
+- If user is in any **admin group** -> `admin` (admin takes priority over manager)
+- Else if user is in any **manager group** -> `manager`
+- Else -> `member`
+- If **neither** `DT_OAUTH2_ADMIN_GROUPS` **nor** `DT_OAUTH2_MANAGER_GROUPS` is configured, roles are not modified at all (preserves existing behavior).
+
+Group matching is **exact-string and case-sensitive**.
+
+### Example: Authentik Configuration
+
+1. Create groups in Authentik (e.g., `donetick-admins`, `donetick-managers`).
+2. Ensure your Authentik OAuth2 provider includes the `groups` scope and that the `groups` claim is returned in the userinfo endpoint.
+3. Set the environment variables:
+   ```yaml
+   environment:
+     - DT_SINGLE_CIRCLE_INSTANCE=true
+     - DT_OAUTH2_ADMIN_GROUPS=donetick-admins
+     - DT_OAUTH2_MANAGER_GROUPS=donetick-managers
+   ```
+
+---
+
 ## Contributing
 
 Contributions are welcome! If you want to work on something that is not listed as an issue, please open a [Discussion](https://github.com/donetick/donetick/discussions) first to ensure it aligns with our goals and to avoid any unnecessary effort!

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	FCM                    FCMConfig           `mapstructure:"fcm" yaml:"fcm"`
 	FeatureLimits          FeatureLimitsConfig `mapstructure:"feature_limits" yaml:"feature_limits"`
 	Storage                StorageConfig       `mapstructure:"storage" yaml:"storage"`
+	SingleCircleInstance   bool                `mapstructure:"single_circle_instance" yaml:"single_circle_instance"`
 	Info                   Info
 }
 
@@ -177,14 +178,16 @@ type EmailConfig struct {
 }
 
 type OAuth2Config struct {
-	ClientID     string   `mapstructure:"client_id" yaml:"client_id"`
-	ClientSecret string   `mapstructure:"client_secret" yaml:"client_secret"`
-	RedirectURL  string   `mapstructure:"redirect_url" yaml:"redirect_url"`
-	Scopes       []string `mapstructure:"scopes" yaml:"scopes"`
-	AuthURL      string   `mapstructure:"auth_url" yaml:"auth_url"`
-	TokenURL     string   `mapstructure:"token_url" yaml:"token_url"`
-	UserInfoURL  string   `mapstructure:"user_info_url" yaml:"user_info_url"`
-	Name         string   `mapstructure:"name" yaml:"name"`
+	ClientID      string   `mapstructure:"client_id" yaml:"client_id"`
+	ClientSecret  string   `mapstructure:"client_secret" yaml:"client_secret"`
+	RedirectURL   string   `mapstructure:"redirect_url" yaml:"redirect_url"`
+	Scopes        []string `mapstructure:"scopes" yaml:"scopes"`
+	AuthURL       string   `mapstructure:"auth_url" yaml:"auth_url"`
+	TokenURL      string   `mapstructure:"token_url" yaml:"token_url"`
+	UserInfoURL   string   `mapstructure:"user_info_url" yaml:"user_info_url"`
+	Name          string   `mapstructure:"name" yaml:"name"`
+	AdminGroups   []string `mapstructure:"admin_groups" yaml:"admin_groups"`
+	ManagerGroups []string `mapstructure:"manager_groups" yaml:"manager_groups"`
 }
 
 type WebhookConfig struct {

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -50,13 +50,23 @@ email:
   user: # optional, will be filled with email.email if not set.  
   appHost:  
 oauth2:
-  client_id: 
-  client_secret: 
-  auth_url: 
-  token_url: 
-  user_info_url: 
-  redirect_url: 
+  client_id:
+  client_secret:
+  auth_url:
+  token_url:
+  user_info_url:
+  redirect_url:
   name:
+  # OIDC group-based role mapping (optional).
+  # Users in these groups get the corresponding role on every OIDC login.
+  # admin_groups:
+  #   - "donetick-admins"
+  # manager_groups:
+  #   - "donetick-managers"
+# Single-circle instance mode (optional).
+# When true, disables circle join/leave endpoints and adds new OIDC users
+# to a shared household circle instead of creating personal circles.
+# single_circle_instance: false
 # Real-time configuration
 realtime:
   enabled: true

--- a/internal/auth/identity_provider.go
+++ b/internal/auth/identity_provider.go
@@ -17,6 +17,7 @@ type IdentityProviderUserInfo struct {
 	DisplayName string
 	Email       string
 	Picture     string
+	Groups      []string
 }
 
 type IdentityProvider struct {
@@ -119,6 +120,15 @@ func (i *IdentityProvider) GetUserInfo(ctx context.Context, accessToken string) 
 		isValid := isPictureURLValid(pictureURL)
 		if isValid {
 			userInfo.Picture = pictureURL
+		}
+	}
+	if val, ok := claims["groups"]; ok {
+		if groups, ok := val.([]interface{}); ok {
+			for _, g := range groups {
+				if s, ok := g.(string); ok {
+					userInfo.Groups = append(userInfo.Groups, s)
+				}
+			}
 		}
 	}
 	return &userInfo, nil

--- a/internal/auth/role_resolver.go
+++ b/internal/auth/role_resolver.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	cModel "donetick.com/core/internal/circle/model"
+)
+
+// ResolveRoleFromGroups determines a user's circle role based on their OIDC group
+// membership. Group matching is exact-string and case-sensitive.
+//
+// Returns (role, true) when group-based role resolution is active (at least one of
+// adminGroups or managerGroups is configured). The resolved role is:
+//   - RoleAdmin if any user group matches an admin group
+//   - RoleManager if any user group matches a manager group
+//   - RoleMember otherwise (no match → member)
+//
+// Returns ("", false) when neither adminGroups nor managerGroups is configured,
+// meaning the caller should skip role sync entirely.
+func ResolveRoleFromGroups(userGroups, adminGroups, managerGroups []string) (cModel.Role, bool) {
+	if len(adminGroups) == 0 && len(managerGroups) == 0 {
+		return "", false
+	}
+
+	groupSet := make(map[string]struct{}, len(userGroups))
+	for _, g := range userGroups {
+		groupSet[g] = struct{}{}
+	}
+
+	for _, ag := range adminGroups {
+		if _, ok := groupSet[ag]; ok {
+			return cModel.RoleAdmin, true
+		}
+	}
+	for _, mg := range managerGroups {
+		if _, ok := groupSet[mg]; ok {
+			return cModel.RoleManager, true
+		}
+	}
+
+	return cModel.RoleMember, true
+}

--- a/internal/auth/role_resolver_test.go
+++ b/internal/auth/role_resolver_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"testing"
+
+	cModel "donetick.com/core/internal/circle/model"
+)
+
+func TestResolveRoleFromGroups(t *testing.T) {
+	tests := []struct {
+		name          string
+		userGroups    []string
+		adminGroups   []string
+		managerGroups []string
+		wantRole      cModel.Role
+		wantActive    bool
+	}{
+		{
+			name:          "no config returns inactive",
+			userGroups:    []string{"some-group"},
+			adminGroups:   nil,
+			managerGroups: nil,
+			wantRole:      "",
+			wantActive:    false,
+		},
+		{
+			name:          "empty config slices returns inactive",
+			userGroups:    []string{"some-group"},
+			adminGroups:   []string{},
+			managerGroups: []string{},
+			wantRole:      "",
+			wantActive:    false,
+		},
+		{
+			name:          "admin match returns admin",
+			userGroups:    []string{"household-admins", "users"},
+			adminGroups:   []string{"household-admins"},
+			managerGroups: []string{"household-managers"},
+			wantRole:      cModel.RoleAdmin,
+			wantActive:    true,
+		},
+		{
+			name:          "manager match returns manager",
+			userGroups:    []string{"household-managers", "users"},
+			adminGroups:   []string{"household-admins"},
+			managerGroups: []string{"household-managers"},
+			wantRole:      cModel.RoleManager,
+			wantActive:    true,
+		},
+		{
+			name:          "admin wins over manager when user in both",
+			userGroups:    []string{"household-admins", "household-managers"},
+			adminGroups:   []string{"household-admins"},
+			managerGroups: []string{"household-managers"},
+			wantRole:      cModel.RoleAdmin,
+			wantActive:    true,
+		},
+		{
+			name:          "no match returns member when config present",
+			userGroups:    []string{"unrelated-group"},
+			adminGroups:   []string{"household-admins"},
+			managerGroups: []string{"household-managers"},
+			wantRole:      cModel.RoleMember,
+			wantActive:    true,
+		},
+		{
+			name:          "empty user groups returns member when config present",
+			userGroups:    nil,
+			adminGroups:   []string{"household-admins"},
+			managerGroups: []string{},
+			wantRole:      cModel.RoleMember,
+			wantActive:    true,
+		},
+		{
+			name:          "case sensitive matching",
+			userGroups:    []string{"Household-Admins"},
+			adminGroups:   []string{"household-admins"},
+			managerGroups: nil,
+			wantRole:      cModel.RoleMember,
+			wantActive:    true,
+		},
+		{
+			name:          "only admin groups configured no match",
+			userGroups:    []string{"users"},
+			adminGroups:   []string{"admins"},
+			managerGroups: nil,
+			wantRole:      cModel.RoleMember,
+			wantActive:    true,
+		},
+		{
+			name:          "only manager groups configured with match",
+			userGroups:    []string{"managers"},
+			adminGroups:   nil,
+			managerGroups: []string{"managers"},
+			wantRole:      cModel.RoleManager,
+			wantActive:    true,
+		},
+		{
+			name:          "multiple admin groups second matches",
+			userGroups:    []string{"super-admins"},
+			adminGroups:   []string{"admins", "super-admins"},
+			managerGroups: nil,
+			wantRole:      cModel.RoleAdmin,
+			wantActive:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, active := ResolveRoleFromGroups(tt.userGroups, tt.adminGroups, tt.managerGroups)
+			if active != tt.wantActive {
+				t.Errorf("active = %v, want %v", active, tt.wantActive)
+			}
+			if role != tt.wantRole {
+				t.Errorf("role = %q, want %q", role, tt.wantRole)
+			}
+		})
+	}
+}

--- a/internal/circle/handler.go
+++ b/internal/circle/handler.go
@@ -27,6 +27,7 @@ type Handler struct {
 	isDonetickDotCom     bool
 	maxCircleMembers     int
 	plusMaxCircleMembers int
+	singleCircleInstance bool
 }
 
 func NewHandler(cr *cRepo.CircleRepository, ur *uRepo.UserRepository, c *chRepo.ChoreRepository, pr *pRepo.PointsRepository,
@@ -39,6 +40,7 @@ func NewHandler(cr *cRepo.CircleRepository, ur *uRepo.UserRepository, c *chRepo.
 		isDonetickDotCom:     config.IsDoneTickDotCom,
 		maxCircleMembers:     config.FeatureLimits.MaxCircleMembers,
 		plusMaxCircleMembers: config.FeatureLimits.PlusCircleMaxMembers,
+		singleCircleInstance: config.SingleCircleInstance,
 	}
 }
 
@@ -784,12 +786,15 @@ func Routes(router *gin.Engine, h *Handler, multiAuthMiddleware *auth.MultiAuthM
 	{
 		circleRoutes.GET("/members", h.GetCircleMembers)
 		circleRoutes.GET("/members/requests", h.GetPendingCircleMembers)
-		circleRoutes.PUT("/members/requests/accept", h.AcceptJoinRequest)
 		circleRoutes.PUT("/members/role", h.ChangeMemberRole)
 		circleRoutes.GET("/", h.GetUserCircles)
-		circleRoutes.POST("/join", h.JoinCircle)
-		circleRoutes.DELETE("/leave", h.LeaveCircle)
-		circleRoutes.DELETE("/:id/members/delete", h.DeleteCircleMember)
 		circleRoutes.POST("/:id/members/points/redeem", h.RedeemPoints)
+
+		if !h.singleCircleInstance {
+			circleRoutes.PUT("/members/requests/accept", h.AcceptJoinRequest)
+			circleRoutes.POST("/join", h.JoinCircle)
+			circleRoutes.DELETE("/leave", h.LeaveCircle)
+			circleRoutes.DELETE("/:id/members/delete", h.DeleteCircleMember)
+		}
 	}
 }

--- a/internal/circle/repo/repository.go
+++ b/internal/circle/repo/repository.go
@@ -92,6 +92,12 @@ func (r *CircleRepository) ChangeUserRole(c context.Context, circleID, userID in
 	return r.db.WithContext(c).Model(&cModel.UserCircle{}).Where("circle_id = ? AND user_id = ?", circleID, userID).Update("role", role).Error
 }
 
+func (r *CircleRepository) GetUserCircleRole(c context.Context, circleID, userID int) (cModel.Role, error) {
+	var role cModel.Role
+	err := r.db.WithContext(c).Model(&cModel.UserCircle{}).Select("role").Where("circle_id = ? AND user_id = ?", circleID, userID).Scan(&role).Error
+	return role, err
+}
+
 func (r *CircleRepository) GetCircleByInviteCode(c context.Context, inviteCode string) (*cModel.Circle, error) {
 	var circle cModel.Circle
 	if err := r.db.WithContext(c).Where("invite_code = ?", inviteCode).First(&circle).Error; err != nil {

--- a/internal/resource/handler.go
+++ b/internal/resource/handler.go
@@ -13,6 +13,7 @@ type Resource struct {
 	APIVersion             string           `json:"api_version" binding:"omitempty"`
 	APICommit              string           `json:"api_commit" binding:"omitempty"`
 	IsUserCreationDisabled bool             `json:"is_user_creation_disabled"`
+	SingleCircleInstance   bool             `json:"single_circle_instance"`
 }
 type identityProvider struct {
 	Auth_url  string `json:"auth_url" binding:"omitempty"`
@@ -41,6 +42,7 @@ func (h *Handler) getResource(c *gin.Context) {
 		APIVersion:             h.config.Info.Version,
 		APICommit:              h.config.Info.Commit,
 		IsUserCreationDisabled: h.config.IsUserCreationDisabled,
+		SingleCircleInstance:   h.config.SingleCircleInstance,
 	})
 }
 

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -50,6 +50,8 @@ type Handler struct {
 	mfaService             *mfa.MFAService
 	maxSubaccounts         int
 	plusMaxSubaccounts     int
+	oauth2Config           config.OAuth2Config
+	singleCircleInstance   bool
 }
 
 func NewHandler(ur *uRepo.UserRepository, cr *cRepo.CircleRepository,
@@ -77,6 +79,8 @@ func NewHandler(ur *uRepo.UserRepository, cr *cRepo.CircleRepository,
 		mfaService:             mfaService,
 		maxSubaccounts:         config.FeatureLimits.MaxSubaccounts,
 		plusMaxSubaccounts:     config.FeatureLimits.PlusMaxSubaccounts,
+		oauth2Config:           config.OAuth2Config,
+		singleCircleInstance:   config.SingleCircleInstance,
 	}
 }
 
@@ -212,6 +216,30 @@ func (h *Handler) GetUserProfile(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"res": user,
 	})
+}
+
+func (h *Handler) syncOIDCRole(c *gin.Context, userID, circleID int, groups []string) {
+	logger := logging.FromContext(c)
+	resolvedRole, active := auth.ResolveRoleFromGroups(groups, h.oauth2Config.AdminGroups, h.oauth2Config.ManagerGroups)
+	if !active {
+		return
+	}
+
+	currentRole, err := h.circleRepo.GetUserCircleRole(c, circleID, userID)
+	if err != nil {
+		logger.Warnw("OIDC role sync: failed to get current role", "userID", userID, "circleID", circleID, "err", err)
+		return
+	}
+
+	if currentRole == cModel.Role(resolvedRole) {
+		return
+	}
+
+	if err := h.circleRepo.ChangeUserRole(c, circleID, userID, resolvedRole); err != nil {
+		logger.Errorw("OIDC role sync: failed to update role", "userID", userID, "circleID", circleID, "resolvedRole", resolvedRole, "err", err)
+		return
+	}
+	logger.Infow("OIDC role sync", "userID", userID, "circleID", circleID, "oldRole", currentRole, "newRole", resolvedRole, "groups", groups)
 }
 
 func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
@@ -628,35 +656,73 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 				return
 
 			}
-			// Create Circle for the user:
-			userCircle, err := h.circleRepo.CreateCircle(c, &cModel.Circle{
-				Name:       claims.DisplayName + "'s circle",
-				CreatedAt:  time.Now().UTC(),
-				UpdatedAt:  time.Now().UTC(),
-				InviteCode: utils.GenerateInviteCode(c),
-			})
+			var circleID int
+			if h.singleCircleInstance {
+				// In single-circle mode, add user to the shared household circle (ID 1).
+				// Create it if it doesn't exist yet (first user bootstraps the circle).
+				sharedCircle, err := h.circleRepo.GetCircleByID(c, 1)
+				if err != nil {
+					sharedCircle, err = h.circleRepo.CreateCircle(c, &cModel.Circle{
+						Name:       "Home",
+						CreatedAt:  time.Now().UTC(),
+						UpdatedAt:  time.Now().UTC(),
+						InviteCode: utils.GenerateInviteCode(c),
+					})
+					if err != nil {
+						c.JSON(500, gin.H{"error": "Error creating shared circle"})
+						return
+					}
+				}
+				circleID = sharedCircle.ID
 
-			if err != nil {
-				c.JSON(500, gin.H{
-					"error": "Error creating circle",
+				// Resolve role from OIDC groups; default to member if no match or no config.
+				role := cModel.UserRole(cModel.RoleMember)
+				if resolvedRole, active := auth.ResolveRoleFromGroups(claims.Groups, h.oauth2Config.AdminGroups, h.oauth2Config.ManagerGroups); active {
+					role = cModel.UserRole(resolvedRole)
+				}
+
+				if err := h.circleRepo.AddUserToCircle(c, &cModel.UserCircle{
+					UserID:    createdUser.ID,
+					CircleID:  circleID,
+					Role:      role,
+					IsActive:  true,
+					CreatedAt: time.Now().UTC(),
+					UpdatedAt: time.Now().UTC(),
+				}); err != nil {
+					c.JSON(500, gin.H{"error": "Error adding user to circle"})
+					return
+				}
+			} else {
+				// Default: create a personal circle for the new user.
+				userCircle, err := h.circleRepo.CreateCircle(c, &cModel.Circle{
+					Name:       claims.DisplayName + "'s circle",
+					CreatedAt:  time.Now().UTC(),
+					UpdatedAt:  time.Now().UTC(),
+					InviteCode: utils.GenerateInviteCode(c),
 				})
-				return
+				if err != nil {
+					c.JSON(500, gin.H{"error": "Error creating circle"})
+					return
+				}
+				circleID = userCircle.ID
+
+				if err := h.circleRepo.AddUserToCircle(c, &cModel.UserCircle{
+					UserID:    createdUser.ID,
+					CircleID:  circleID,
+					Role:      "admin",
+					IsActive:  true,
+					CreatedAt: time.Now().UTC(),
+					UpdatedAt: time.Now().UTC(),
+				}); err != nil {
+					c.JSON(500, gin.H{"error": "Error adding user to circle"})
+					return
+				}
+
+				// Sync role from OIDC groups if configured (may demote from admin).
+				h.syncOIDCRole(c, createdUser.ID, circleID, claims.Groups)
 			}
 
-			if err := h.circleRepo.AddUserToCircle(c, &cModel.UserCircle{
-				UserID:    createdUser.ID,
-				CircleID:  userCircle.ID,
-				Role:      "admin",
-				IsActive:  true,
-				CreatedAt: time.Now().UTC(),
-				UpdatedAt: time.Now().UTC(),
-			}); err != nil {
-				c.JSON(500, gin.H{
-					"error": "Error adding user to circle",
-				})
-				return
-			}
-			createdUser.CircleID = userCircle.ID
+			createdUser.CircleID = circleID
 			if err := h.userRepo.UpdateUser(c, createdUser); err != nil {
 				c.JSON(500, gin.H{
 					"error": "Error updating user",
@@ -704,6 +770,8 @@ func (h *Handler) thirdPartyAuthCallback(c *gin.Context) {
 				logger.Warn("Failed to update profile image", "userID", acc.ID, "err", err)
 			}
 		}
+		// Sync role from OIDC groups on every login (IdP is source of truth).
+		h.syncOIDCRole(c, acc.ID, acc.CircleID, claims.Groups)
 		// Generate tokens including refresh token:
 		tokenResponse, err := h.tokenService.GenerateTokens(c.Request.Context(), acc)
 		if err != nil {


### PR DESCRIPTION
Simplifies self-hosting for single households where everyone shares one circle and permissions are managed centrally via an external IdP. 

Changes:
* Single-circle mode (`DT_SINGLE_CIRCLE_INSTANCE`): When enabled, disables circle management endpoints (`/join`, `/leave`, etc.). New OIDC users are automatically dropped into a shared "Home" circle (ID 1) instead of getting personal circles.
* OIDC role sync (`DT_OAUTH2_ADMIN_GROUPS`, `DT_OAUTH2_MANAGER_GROUPS`): Maps IdP groups to Donetick roles. This syncs on *every* login using the `groups` claim, making the IdP the source of truth.
* Exposed the single-circle state in `GET /resource/info` so the frontend can hide the circle management UI.
* Added unit tests for the role resolver logic.

Fully backwards compatible. Both features are disabled by default to preserve existing behavior.