### PR TITLE
Offline Support: Add Synchronization and Versioning

### DIFF
--- a/internal/chore/api.go
+++ b/internal/chore/api.go
@@ -45,7 +45,7 @@ func NewAPI(cr *chRepo.ChoreRepository, userRepo *uRepo.UserRepository, circleRe
 
 func (h *API) GetAllChores(c *gin.Context) {
 	user := auth.MustCurrentUser(c)
-	chores, err := h.choreRepo.GetChores(c, user.CircleID, user.ID, false)
+	chores, err := h.choreRepo.GetChores(c, user.CircleID, user.ID, false, nil)
 	if err != nil {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -115,7 +115,7 @@ func (h *Handler) GetChores(c *gin.Context) {
 		includeArchived = true
 	}
 
-	chores, err := h.choreRepo.GetChores(c, u.CircleID, u.ID, includeArchived)
+	chores, err := h.choreRepo.GetChores(c, u.CircleID, u.ID, includeArchived, nil)
 	if err != nil {
 		logger.Error("Failed to retrieve chores", "error", err, "userID", u.ID, "circleID", u.CircleID, "includeArchived", includeArchived)
 		c.JSON(500, gin.H{

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -258,6 +259,92 @@ type ChoreReq struct {
 	IsPrivate            *bool                         `json:"isPrivate" binding:"required"`
 	ProjectID            *int                          `json:"projectId" binding:"omitempty,gt=0"`
 	ThingTrigger         *tModel.ThingTrigger          `json:"thingTrigger"`
+}
+
+type ActionOptions struct {
+	CreatedAt   time.Time  `json:"createdAt"`
+	SyncVersion int64      `json:"syncVersion"`
+	NextDueDate *time.Time `json:"nextDueDate"`
+}
+
+type ActionReq struct {
+	ActionOptions *ActionOptions `json:"actionOptions"`
+}
+
+func bindOptionalActionReq(c *gin.Context, req interface{}) error {
+	if c.Request == nil || c.Request.Body == nil || c.Request.ContentLength == 0 {
+		return nil
+	}
+
+	if err := c.ShouldBindJSON(req); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func validateActionVersion(c *gin.Context, actionName string, chore *chModel.Chore, options *ActionOptions) bool {
+	if options == nil {
+		return true
+	}
+
+	if options.SyncVersion == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "actionOptions.syncVersion is required",
+		})
+		return false
+	}
+
+	if options.SyncVersion != chore.SyncVersion {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":          fmt.Sprintf("%s version mismatch: action version %d does not match current chore version %d", actionName, options.SyncVersion, chore.SyncVersion),
+			"actionVersion":  options.SyncVersion,
+			"currentVersion": chore.SyncVersion,
+		})
+		return false
+	}
+
+	return true
+}
+
+func actionCreatedAtOrNow(options *ActionOptions) time.Time {
+	if options != nil && !options.CreatedAt.IsZero() {
+		return options.CreatedAt.UTC()
+	}
+
+	return time.Now().UTC()
+}
+
+func applyStartActionTime(session *chModel.TimeSession, userID int, actionTime time.Time) {
+	actionTime = actionTime.UTC()
+	session.StartTime = actionTime
+	if len(session.PauseLog) > 0 {
+		session.PauseLog[len(session.PauseLog)-1].StartTime = actionTime
+	}
+	session.UpdateBy = userID
+	session.UpdateAt = actionTime
+}
+
+func applyPauseActionTime(session *chModel.TimeSession, userID int, actionTime time.Time) {
+	actionTime = actionTime.UTC()
+	if len(session.PauseLog) > 0 {
+		lastLog := session.PauseLog[len(session.PauseLog)-1]
+		if lastLog.EndTime != nil {
+			previousDuration := lastLog.Duration
+			lastLog.EndTime = &actionTime
+			recalculatedDuration := int(actionTime.Sub(lastLog.StartTime).Seconds())
+			if recalculatedDuration < 0 {
+				recalculatedDuration = 0
+			}
+			lastLog.Duration = recalculatedDuration
+			session.Duration += recalculatedDuration - previousDuration
+		}
+	}
+	session.UpdateBy = userID
+	session.UpdateAt = actionTime
 }
 
 // endregion
@@ -1061,6 +1148,14 @@ func (h *Handler) UpdateAssignee(c *gin.Context) {
 //	@Failure		500	{object}	map[string]string		"error: Failed to retrieve chore | Error creating time session"
 //	@Router			/chores/{id}/start [put]
 func (h *Handler) StartChore(c *gin.Context) {
+	var req ActionReq
+	if err := bindOptionalActionReq(c, &req); err != nil {
+		c.JSON(400, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
 	rawID := c.Param("id")
 	id, err := strconv.Atoi(rawID)
 
@@ -1102,6 +1197,10 @@ func (h *Handler) StartChore(c *gin.Context) {
 		})
 		return
 	}
+	if !validateActionVersion(c, "start", chore, req.ActionOptions) {
+		return
+	}
+	actionTime := actionCreatedAtOrNow(req.ActionOptions)
 	circleUsers, err := h.circleRepo.GetCircleUsers(c, actualUser.CircleID)
 	if err != nil {
 		logger.Error("Failed to retrieve circle users", "error", err)
@@ -1117,6 +1216,7 @@ func (h *Handler) StartChore(c *gin.Context) {
 		return
 	}
 	var session *chModel.TimeSession
+	var updatedSyncVersion int64
 	switch chore.Status {
 	case chModel.ChoreStatusNoStatus:
 		session, err = h.choreRepo.CreateTimeSession(c, chore, effectiveUser.ID)
@@ -1126,7 +1226,17 @@ func (h *Handler) StartChore(c *gin.Context) {
 			})
 			return
 		}
-		if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+		if req.ActionOptions != nil && !req.ActionOptions.CreatedAt.IsZero() {
+			applyStartActionTime(session, effectiveUser.ID, actionTime)
+			if err := h.choreRepo.UpdateTimeSession(c, session); err != nil {
+				c.JSON(500, gin.H{
+					"error": "Error updating time session",
+				})
+				return
+			}
+		}
+		updatedSyncVersion, err = h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+		if err != nil {
 			c.JSON(500, gin.H{
 				"error": "Error updating chore status",
 			})
@@ -1142,6 +1252,9 @@ func (h *Handler) StartChore(c *gin.Context) {
 		}
 		if session != nil {
 			session.Start(effectiveUser.ID)
+			if req.ActionOptions != nil && !req.ActionOptions.CreatedAt.IsZero() {
+				applyStartActionTime(session, effectiveUser.ID, actionTime)
+			}
 			if err := h.choreRepo.UpdateTimeSession(c, session); err != nil {
 				c.JSON(500, gin.H{
 					"error": "Error updating time session",
@@ -1149,7 +1262,8 @@ func (h *Handler) StartChore(c *gin.Context) {
 				return
 			}
 		}
-		if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+		updatedSyncVersion, err = h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+		if err != nil {
 			c.JSON(500, gin.H{
 				"error": "Error updating chore status",
 			})
@@ -1162,6 +1276,7 @@ func (h *Handler) StartChore(c *gin.Context) {
 		})
 		return
 	}
+	chore.SyncVersion = updatedSyncVersion
 	if h.realTimeService != nil {
 		chore.Status = chModel.ChoreStatusInProgress
 		broadcaster := h.realTimeService.GetEventBroadcaster()
@@ -1181,6 +1296,7 @@ func (h *Handler) StartChore(c *gin.Context) {
 				"timerUpdatedAt": session.UpdateAt,
 				"status":         chModel.ChoreStatusInProgress,
 				"duration":       session.Duration,
+				"syncVersion":    updatedSyncVersion,
 			},
 		})
 	}
@@ -1203,6 +1319,14 @@ func (h *Handler) StartChore(c *gin.Context) {
 //	@Failure		500	{object}	map[string]string		"error: Failed to retrieve chore | Error getting active time session"
 //	@Router			/chores/{id}/pause [put]
 func (h *Handler) PauseChore(c *gin.Context) {
+	var req ActionReq
+	if err := bindOptionalActionReq(c, &req); err != nil {
+		c.JSON(400, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
 	rawID := c.Param("id")
 	id, err := strconv.Atoi(rawID)
 
@@ -1244,6 +1368,10 @@ func (h *Handler) PauseChore(c *gin.Context) {
 		})
 		return
 	}
+	if !validateActionVersion(c, "pause", chore, req.ActionOptions) {
+		return
+	}
+	actionTime := actionCreatedAtOrNow(req.ActionOptions)
 	circleUsers, err := h.circleRepo.GetCircleUsers(c, actualUser.CircleID)
 	if err != nil {
 		logger.Error("Failed to retrieve circle users", "error", err)
@@ -1273,18 +1401,23 @@ func (h *Handler) PauseChore(c *gin.Context) {
 		return
 	}
 	session.Pause(effectiveUser.ID)
+	if req.ActionOptions != nil && !req.ActionOptions.CreatedAt.IsZero() {
+		applyPauseActionTime(session, effectiveUser.ID, actionTime)
+	}
 	if err := h.choreRepo.UpdateTimeSession(c, session); err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error updating time session",
 		})
 		return
 	}
-	if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused, chore.CircleID); err != nil {
+	updatedSyncVersion, err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused, chore.CircleID)
+	if err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error updating chore status",
 		})
 		return
 	}
+	chore.SyncVersion = updatedSyncVersion
 	if h.realTimeService != nil {
 		chore.Status = chModel.ChoreStatusPaused
 		broadcaster := h.realTimeService.GetEventBroadcaster()
@@ -1303,6 +1436,7 @@ func (h *Handler) PauseChore(c *gin.Context) {
 			"duration":       session.Duration,
 			"status":         chModel.ChoreStatusPaused,
 			"timerUpdatedAt": session.UpdateAt,
+			"syncVersion":    updatedSyncVersion,
 		},
 	})
 
@@ -1406,12 +1540,14 @@ func (h *Handler) ResetChoreTimer(c *gin.Context) {
 	}
 
 	// Update chore status to in progress
-	if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+	updatedSyncVersion, err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+	if err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error updating chore status",
 		})
 		return
 	}
+	chore.SyncVersion = updatedSyncVersion
 
 	// Broadcast the change via real-time service
 	if h.realTimeService != nil {
@@ -1432,6 +1568,7 @@ func (h *Handler) ResetChoreTimer(c *gin.Context) {
 			"timerUpdatedAt": session.UpdateAt,
 			"status":         chModel.ChoreStatusInProgress,
 			"duration":       session.Duration,
+			"syncVersion":    updatedSyncVersion,
 		},
 	})
 }
@@ -1452,6 +1589,14 @@ func (h *Handler) ResetChoreTimer(c *gin.Context) {
 //	@Failure		500	{object}	map[string]string			"error: Failed to retrieve chore | Error scheduling next due date | Error completing chore"
 //	@Router			/chores/{id}/skip [post]
 func (h *Handler) SkipChore(c *gin.Context) {
+	var req ActionReq
+	if err := bindOptionalActionReq(c, &req); err != nil {
+		c.JSON(400, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
 	rawID := c.Param("id")
 	id, err := strconv.Atoi(rawID)
 
@@ -1493,16 +1638,31 @@ func (h *Handler) SkipChore(c *gin.Context) {
 		})
 		return
 	}
-	nextDueDate, err := scheduleNextDueDate(c, chore, chore.NextDueDate.UTC())
-	if err != nil {
-		c.JSON(500, gin.H{
-			"error": "Error scheduling next due date",
-		})
+	if !validateActionVersion(c, "skip", chore, req.ActionOptions) {
 		return
 	}
 
+	var nextDueDate *time.Time
+	if req.ActionOptions != nil && req.ActionOptions.NextDueDate != nil {
+		t := req.ActionOptions.NextDueDate.UTC()
+		nextDueDate = &t
+	} else {
+		nextDueDate, err = scheduleNextDueDate(c, chore, chore.NextDueDate.UTC())
+		if err != nil {
+			c.JSON(500, gin.H{
+				"error": "Error scheduling next due date",
+			})
+			return
+		}
+	}
+
 	nextAssignedTo := chore.AssignedTo
-	if err := h.choreRepo.SkipChore(c, chore, effectiveUser.ID, nextDueDate, nextAssignedTo); err != nil {
+	var skippedAt *time.Time
+	if req.ActionOptions != nil && !req.ActionOptions.CreatedAt.IsZero() {
+		t := req.ActionOptions.CreatedAt.UTC()
+		skippedAt = &t
+	}
+	if err := h.choreRepo.SkipChore(c, chore, effectiveUser.ID, nextDueDate, nextAssignedTo, skippedAt); err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error completing chore",
 		})
@@ -1789,10 +1949,11 @@ func (h *Handler) UnarchiveChore(c *gin.Context) {
 // region: request models
 
 type CompleteChoreReq struct { // TODO: Remove "Note" in future.
-	Notes         *string    `json:"notes" binding:"omitempty,min=1"`
-	Note          *string    `json:"note" binding:"omitempty,min=1"` // This is going to be deprecated in future release, use "Notes" instead.
-	CompletedBy   *int       `json:"completedBy"`                    // The completed by only can be populated by the admin or super user.
-	CompletedDate *time.Time `json:"completedTime"`                  // Completion date in RFC3339 format (defaults to now).
+	Notes         *string        `json:"notes" binding:"omitempty,min=1"`
+	Note          *string        `json:"note" binding:"omitempty,min=1"` // This is going to be deprecated in future release, use "Notes" instead.
+	CompletedBy   *int           `json:"completedBy"`                    // The completed by only can be populated by the admin or super user.
+	CompletedDate *time.Time     `json:"completedTime"`                  // Completion date in RFC3339 format (defaults to now).
+	ActionOptions *ActionOptions `json:"actionOptions"`
 }
 
 // endregion
@@ -1853,7 +2014,7 @@ func (h *Handler) CompleteChore(c *gin.Context) {
 
 	var completedDate time.Time
 	if req.CompletedDate == nil {
-		completedDate = time.Now().UTC()
+		completedDate = actionCreatedAtOrNow(req.ActionOptions)
 	} else {
 		completedDate = req.CompletedDate.UTC()
 	}
@@ -1871,6 +2032,9 @@ func (h *Handler) CompleteChore(c *gin.Context) {
 		c.JSON(500, gin.H{
 			"error": "Failed to retrieve chore",
 		})
+		return
+	}
+	if !validateActionVersion(c, "complete", chore, req.ActionOptions) {
 		return
 	}
 
@@ -3010,14 +3174,17 @@ func (h *Handler) DeleteTimeSession(c *gin.Context) {
 		return
 	}
 	if chore.Status == chModel.ChoreStatusInProgress || chore.Status == chModel.ChoreStatusPaused {
-		if err := h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus, chore.CircleID); err != nil {
+		updatedSyncVersion, err := h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus, chore.CircleID)
+		if err != nil {
 			c.JSON(500, gin.H{
 				"error": "Error updating chore status",
 			})
 			return
 		}
+		chore.SyncVersion = updatedSyncVersion
 		c.JSON(200, gin.H{
-			"message": "Time session deleted successfully",
+			"message":     "Time session deleted successfully",
+			"syncVersion": updatedSyncVersion,
 		})
 
 		return
@@ -3051,6 +3218,14 @@ func (h *Handler) ApproveChore(c *gin.Context) {
 		return
 	}
 
+	var req ActionReq
+	if err := bindOptionalActionReq(c, &req); err != nil {
+		c.JSON(400, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
 	rawID := c.Param("id")
 	id, err := strconv.Atoi(rawID)
 	if err != nil {
@@ -3067,6 +3242,9 @@ func (h *Handler) ApproveChore(c *gin.Context) {
 		c.JSON(500, gin.H{
 			"error": "Failed to retrieve chore",
 		})
+		return
+	}
+	if !validateActionVersion(c, "approve", chore, req.ActionOptions) {
 		return
 	}
 
@@ -3207,8 +3385,9 @@ func (h *Handler) ApproveChore(c *gin.Context) {
 // region: request models
 
 type RejectChoreReq struct { // TODO: Remove "Note" in future.
-	Notes *string `json:"notes" binding:"omitempty,min=1"`
-	Note  *string `json:"note" binding:"omitempty,min=1"` // This is going to be deprecated in future release, use "Notes" instead.
+	Notes         *string        `json:"notes" binding:"omitempty,min=1"`
+	Note          *string        `json:"note" binding:"omitempty,min=1"` // This is going to be deprecated in future release, use "Notes" instead.
+	ActionOptions *ActionOptions `json:"actionOptions"`
 }
 
 // endregion
@@ -3264,6 +3443,9 @@ func (h *Handler) RejectChore(c *gin.Context) {
 		c.JSON(500, gin.H{
 			"error": "Failed to retrieve chore",
 		})
+		return
+	}
+	if !validateActionVersion(c, "reject", chore, req.ActionOptions) {
 		return
 	}
 

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -1126,7 +1126,12 @@ func (h *Handler) StartChore(c *gin.Context) {
 			})
 			return
 		}
-		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+		if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+			c.JSON(500, gin.H{
+				"error": "Error updating chore status",
+			})
+			return
+		}
 	case chModel.ChoreStatusPaused:
 		session, err = h.choreRepo.GetActiveTimeSession(c, chore.ID)
 		if err != nil {
@@ -1144,7 +1149,12 @@ func (h *Handler) StartChore(c *gin.Context) {
 				return
 			}
 		}
-		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+		if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+			c.JSON(500, gin.H{
+				"error": "Error updating chore status",
+			})
+			return
+		}
 
 	default:
 		c.JSON(400, gin.H{
@@ -1269,7 +1279,12 @@ func (h *Handler) PauseChore(c *gin.Context) {
 		})
 		return
 	}
-	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused, chore.CircleID)
+	if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused, chore.CircleID); err != nil {
+		c.JSON(500, gin.H{
+			"error": "Error updating chore status",
+		})
+		return
+	}
 	if h.realTimeService != nil {
 		chore.Status = chModel.ChoreStatusPaused
 		broadcaster := h.realTimeService.GetEventBroadcaster()
@@ -1391,7 +1406,12 @@ func (h *Handler) ResetChoreTimer(c *gin.Context) {
 	}
 
 	// Update chore status to in progress
-	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
+	if err := h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID); err != nil {
+		c.JSON(500, gin.H{
+			"error": "Error updating chore status",
+		})
+		return
+	}
 
 	// Broadcast the change via real-time service
 	if h.realTimeService != nil {
@@ -2990,7 +3010,12 @@ func (h *Handler) DeleteTimeSession(c *gin.Context) {
 		return
 	}
 	if chore.Status == chModel.ChoreStatusInProgress || chore.Status == chModel.ChoreStatusPaused {
-		h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus, chore.CircleID)
+		if err := h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus, chore.CircleID); err != nil {
+			c.JSON(500, gin.H{
+				"error": "Error updating chore status",
+			})
+			return
+		}
 		c.JSON(200, gin.H{
 			"message": "Time session deleted successfully",
 		})
@@ -3284,7 +3309,6 @@ func (h *Handler) RejectChore(c *gin.Context) {
 	if req.Note != nil {
 		note = req.Note
 	}
-
 
 	// Reject the chore
 	if err := h.choreRepo.RejectChore(c, id, currentUser.CircleID, note); err != nil {

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -2483,7 +2483,7 @@ func (h *Handler) DeleteHistory(c *gin.Context) {
 		return
 	}
 
-	if err := h.choreRepo.DeleteChoreHistory(c, historyID); err != nil {
+	if err := h.choreRepo.DeleteChoreHistory(c, historyID, currentUser.CircleID); err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error deleting history",
 		})

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -1099,7 +1099,7 @@ func (h *Handler) startChore(c *gin.Context) {
 			})
 			return
 		}
-		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress)
+		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
 	case chModel.ChoreStatusPaused:
 		session, err = h.choreRepo.GetActiveTimeSession(c, chore.ID)
 		if err != nil {
@@ -1117,7 +1117,7 @@ func (h *Handler) startChore(c *gin.Context) {
 				return
 			}
 		}
-		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress)
+		h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
 
 	default:
 		c.JSON(400, gin.H{
@@ -1242,7 +1242,7 @@ func (h *Handler) pauseChore(c *gin.Context) {
 		})
 		return
 	}
-	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused)
+	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusPaused, chore.CircleID)
 	if h.realTimeService != nil {
 		chore.Status = chModel.ChoreStatusPaused
 		broadcaster := h.realTimeService.GetEventBroadcaster()
@@ -1364,7 +1364,7 @@ func (h *Handler) ResetChoreTimer(c *gin.Context) {
 	}
 
 	// Update chore status to in progress
-	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress)
+	h.choreRepo.UpdateChoreStatus(c, chore.ID, chModel.ChoreStatusInProgress, chore.CircleID)
 
 	// Broadcast the change via real-time service
 	if h.realTimeService != nil {
@@ -1653,7 +1653,7 @@ func (h *Handler) archiveChore(c *gin.Context) {
 		return
 	}
 
-	err = h.choreRepo.ArchiveChore(c, id, currentUser.ID)
+	err = h.choreRepo.ArchiveChore(c, id, currentUser.ID, currentUser.CircleID)
 
 	if err != nil {
 		c.JSON(500, gin.H{
@@ -1715,7 +1715,7 @@ func (h *Handler) UnarchiveChore(c *gin.Context) {
 		})
 		return
 	}
-	err = h.choreRepo.UnarchiveChore(c, id, currentUser.ID)
+	err = h.choreRepo.UnarchiveChore(c, id, currentUser.ID, currentUser.CircleID)
 
 	if err != nil {
 		c.JSON(500, gin.H{
@@ -2333,7 +2333,7 @@ func (h *Handler) updatePriority(c *gin.Context) {
 		return
 	}
 
-	if err := h.choreRepo.UpdateChorePriority(c, currentUser.ID, id, *priorityReq.Priority); err != nil {
+	if err := h.choreRepo.UpdateChorePriority(c, currentUser.ID, id, *priorityReq.Priority, chore.CircleID); err != nil {
 		logger.Error("Failed to update priority", "error", err)
 		c.JSON(500, gin.H{
 			"error": "Error updating priority",
@@ -2944,7 +2944,7 @@ func (h *Handler) DeleteTimeSession(c *gin.Context) {
 		return
 	}
 	if chore.Status == chModel.ChoreStatusInProgress || chore.Status == chModel.ChoreStatusPaused {
-		h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus)
+		h.choreRepo.UpdateChoreStatus(c, choreID, chModel.ChoreStatusNoStatus, chore.CircleID)
 		c.JSON(200, gin.H{
 			"message": "Time session deleted successfully",
 		})
@@ -3225,7 +3225,7 @@ func (h *Handler) rejectChore(c *gin.Context) {
 	}
 
 	// Reject the chore
-	if err := h.choreRepo.RejectChore(c, id, rejectionNote); err != nil {
+	if err := h.choreRepo.RejectChore(c, id, currentUser.CircleID, rejectionNote); err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error rejecting chore",
 		})
@@ -3898,7 +3898,7 @@ func (h *Handler) undoChore(c *gin.Context) {
 	}
 
 	// Perform the undo
-	err = h.choreRepo.UndoChoreAction(c, choreID, lastAction.ID, previousAssignedTo, previousDueDate)
+	err = h.choreRepo.UndoChoreAction(c, choreID, lastAction.ID, currentUser.CircleID, previousAssignedTo, previousDueDate)
 	if err != nil {
 		logger.Error("Failed to undo chore action", "error", err)
 		c.JSON(500, gin.H{

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -105,7 +105,7 @@ type ChoreHistory struct {
 	Status      ChoreHistoryStatus `json:"status" gorm:"column:status"`                                 // Status of the chore (1=completed, 2=skipped)
 	Points      *int               `json:"points,omitempty" gorm:"column:points"`                       // Points for completing the chore
 	Duration    *int               `json:"duration,omitempty" gorm:"<-:false;-:migration"`              // Duration in seconds calculated from query (read-only, no DB column)
-	SyncVersion int64              `json:"syncVersion" gorm:"column:sync_version;not null;default:0"`
+	SyncVersion int64              `json:"syncVersion" gorm:"column:sync_version;not null;default:0;index:idx_chore_history_sync_version"`
 }
 
 type ChoreHistoryStatus int8

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -79,6 +79,7 @@ type Chore struct {
 	DeadlineOffset         *int                  `json:"deadlineOffset,omitempty" gorm:"column:deadline_offset"`      // Seconds after NextDueDate when chore deadline is reached
 	ProjectID              *int                  `json:"projectId,omitempty" gorm:"column:project_id;index"`          // The project this chore belongs to
 	Project                *pModel.Project       `json:"project,omitempty" gorm:"foreignkey:ProjectID;references:ID"` // Project relationship
+	SyncVersion            int64                 `json:"syncVersion" gorm:"column:sync_version;not null;default:0;index"`
 }
 
 type Status int8
@@ -103,11 +104,12 @@ type ChoreHistory struct {
 	AssignedTo  *int               `json:"assignedTo" gorm:"column:assigned_to"`              // Who the chore was assigned to
 	Note        *string            `json:"notes" gorm:"column:notes"`                         // Notes about the chore
 	DueDate     *time.Time         `json:"dueDate" gorm:"column:due_date"`                    // When the chore was due
-	UpdatedAt   *time.Time         `json:"updatedAt" gorm:"column:updated_at"`                // When the record was last updated
-	CreatedAt   time.Time          `json:"createdAt" gorm:"column:created_at;autoCreateTime"` // When the record was created
+	UpdatedAt   *time.Time         `json:"updatedAt" gorm:"column:updated_at"`                            // When the record was last updated
+	CreatedAt   time.Time          `json:"createdAt" gorm:"column:created_at;autoCreateTime;<-:create"` // When the record was created (immutable after insert)
 	Status      ChoreHistoryStatus `json:"status" gorm:"column:status"`                       // Status of the chore (1=completed, 2=skipped)
 	Points      *int               `json:"points,omitempty" gorm:"column:points"`             // Points for completing the chore
 	Duration    *int               `json:"duration,omitempty" gorm:"<-:false;-:migration"`    // Duration in seconds calculated from query (read-only, no DB column)
+	SyncVersion int64              `json:"syncVersion" gorm:"column:sync_version;not null;default:0"`
 }
 
 type ChoreHistoryStatus int8

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -46,37 +46,36 @@ const (
 
 type Chore struct {
 	ID                     int                   `json:"id" gorm:"primary_key"`
-	Name                   string                `json:"name" gorm:"column:name"`                                           // Chore description
-	FrequencyType          FrequencyType         `json:"frequencyType" gorm:"column:frequency_type"`                        // "daily", "weekly", "monthly", "yearly", "adaptive",or "custom"
-	Frequency              int                   `json:"frequency" gorm:"column:frequency"`                                 // Number of days, weeks, months, or years between chores
-	FrequencyMetadataV2    *FrequencyMetadata    `json:"frequencyMetadata" gorm:"column:frequency_meta_v2;type:json"`       // Additional frequency information for v2 (if used)
-	NextDueDate            *time.Time            `json:"nextDueDate" gorm:"column:next_due_date;index"`                     // When the chore is due
-	IsRolling              bool                  `json:"isRolling" gorm:"column:is_rolling"`                                // Whether the chore is rolling
-	AssignedTo             *int                  `json:"assignedTo" gorm:"column:assigned_to"`                              // Who the chore is assigned to
-	Assignees              []ChoreAssignees      `json:"assignees" gorm:"foreignkey:ChoreID;references:ID"`                 // Assignees of the chore
-	AssignStrategy         AssignmentStrategy    `json:"assignStrategy" gorm:"column:assign_strategy"`                      // How the chore is assigned
-	IsActive               bool                  `json:"isActive" gorm:"column:is_active"`                                  // Whether the chore is active
-	Notification           bool                  `json:"notification" gorm:"column:notification"`                           // Whether the chore has notification
-	NotificationMetadataV2 *NotificationMetadata `json:"notificationMetadata" gorm:"column:notification_meta_v2;type:json"` // Additional notification information
-	LabelsV2               *[]lModel.Label       `json:"labelsV2" gorm:"many2many:chore_labels"`                            // Labels for the chore
-	CircleID               int                   `json:"circleId" gorm:"column:circle_id;index"`                            // The circle this chore is in
-	CreatedAt              time.Time             `json:"createdAt" gorm:"column:created_at"`                                // When the chore was created
-	UpdatedAt              time.Time             `json:"updatedAt" gorm:"column:updated_at"`                                // When the chore was last updated
-	CreatedBy              int                   `json:"createdBy" gorm:"column:created_by"`                                // Who created the chore
-	UpdatedBy              int                   `json:"updatedBy" gorm:"column:updated_by"`                                // Who last updated the chore
-	ThingChore             *tModel.ThingChore    `json:"thingChore" gorm:"foreignkey:chore_id;references:id;<-:false"`      // ThingChore relationship
-	Status                 Status                `json:"status" gorm:"column:status"`                                       //
-	Priority               int                   `json:"priority" gorm:"column:priority"`                                   //
-	CompletionWindow       *int                  `json:"completionWindow,omitempty" gorm:"column:completion_window"`        // Number seconds before the chore is due that it can be completed
-	Points                 *int                  `json:"points,omitempty" gorm:"column:points"`                             // Points for completing the chore
-	Description            *string               `json:"description,omitempty" gorm:"type:text;column:description"`         // Description of the chore
-	SubTasks               *[]stModel.SubTask    `json:"subTasks,omitempty" gorm:"foreignkey:ChoreID;references:ID"`        // Subtasks for the chore
-	RequireApproval        bool                  `json:"requireApproval" gorm:"column:require_approval"`                    // Whether chore completion requires admin approval
-	IsPrivate              bool                  `json:"isPrivate" gorm:"column:is_private;default:false"`                  // Whether the chore is private
-	ProjectID              *int                  `json:"projectId,omitempty" gorm:"column:project_id;index"`                // The project this chore belongs to
-	Project                *pModel.Project       `json:"project,omitempty" gorm:"foreignkey:ProjectID;references:ID"`       // Project relationship
-  SyncVersion            int64                 `json:"syncVersion" gorm:"column:sync_version;not null;default:0;index"`
-
+	Name                   string                `json:"name" gorm:"column:name"`                                                                // Chore description
+	FrequencyType          FrequencyType         `json:"frequencyType" gorm:"column:frequency_type"`                                             // "daily", "weekly", "monthly", "yearly", "adaptive",or "custom"
+	Frequency              int                   `json:"frequency" gorm:"column:frequency"`                                                      // Number of days, weeks, months, or years between chores
+	FrequencyMetadataV2    *FrequencyMetadata    `json:"frequencyMetadata" gorm:"column:frequency_meta_v2;type:json"`                            // Additional frequency information for v2 (if used)
+	NextDueDate            *time.Time            `json:"nextDueDate" gorm:"column:next_due_date;index"`                                          // When the chore is due
+	IsRolling              bool                  `json:"isRolling" gorm:"column:is_rolling"`                                                     // Whether the chore is rolling
+	AssignedTo             *int                  `json:"assignedTo" gorm:"column:assigned_to"`                                                   // Who the chore is assigned to
+	Assignees              []ChoreAssignees      `json:"assignees" gorm:"foreignkey:ChoreID;references:ID"`                                      // Assignees of the chore
+	AssignStrategy         AssignmentStrategy    `json:"assignStrategy" gorm:"column:assign_strategy"`                                           // How the chore is assigned
+	IsActive               bool                  `json:"isActive" gorm:"column:is_active"`                                                       // Whether the chore is active
+	Notification           bool                  `json:"notification" gorm:"column:notification"`                                                // Whether the chore has notification
+	NotificationMetadataV2 *NotificationMetadata `json:"notificationMetadata" gorm:"column:notification_meta_v2;type:json"`                      // Additional notification information
+	LabelsV2               *[]lModel.Label       `json:"labelsV2" gorm:"many2many:chore_labels"`                                                 // Labels for the chore
+	CircleID               int                   `json:"circleId" gorm:"column:circle_id;index;index:idx_chores_circle_sync_version,priority:1"` // The circle this chore is in
+	CreatedAt              time.Time             `json:"createdAt" gorm:"column:created_at"`                                                     // When the chore was created
+	UpdatedAt              time.Time             `json:"updatedAt" gorm:"column:updated_at"`                                                     // When the chore was last updated
+	CreatedBy              int                   `json:"createdBy" gorm:"column:created_by"`                                                     // Who created the chore
+	UpdatedBy              int                   `json:"updatedBy" gorm:"column:updated_by"`                                                     // Who last updated the chore
+	ThingChore             *tModel.ThingChore    `json:"thingChore" gorm:"foreignkey:chore_id;references:id;<-:false"`                           // ThingChore relationship
+	Status                 Status                `json:"status" gorm:"column:status"`                                                            //
+	Priority               int                   `json:"priority" gorm:"column:priority"`                                                        //
+	CompletionWindow       *int                  `json:"completionWindow,omitempty" gorm:"column:completion_window"`                             // Number seconds before the chore is due that it can be completed
+	Points                 *int                  `json:"points,omitempty" gorm:"column:points"`                                                  // Points for completing the chore
+	Description            *string               `json:"description,omitempty" gorm:"type:text;column:description"`                              // Description of the chore
+	SubTasks               *[]stModel.SubTask    `json:"subTasks,omitempty" gorm:"foreignkey:ChoreID;references:ID"`                             // Subtasks for the chore
+	RequireApproval        bool                  `json:"requireApproval" gorm:"column:require_approval"`                                         // Whether chore completion requires admin approval
+	IsPrivate              bool                  `json:"isPrivate" gorm:"column:is_private;default:false"`                                       // Whether the chore is private
+	ProjectID              *int                  `json:"projectId,omitempty" gorm:"column:project_id;index"`                                     // The project this chore belongs to
+	Project                *pModel.Project       `json:"project,omitempty" gorm:"foreignkey:ProjectID;references:ID"`                            // Project relationship
+	SyncVersion            int64                 `json:"syncVersion" gorm:"column:sync_version;not null;default:0;index;index:idx_chores_circle_sync_version,priority:2"`
 }
 
 type Status int8
@@ -94,18 +93,18 @@ type ChoreAssignees struct {
 	UserID  int `json:"userId" gorm:"column:user_id;uniqueIndex:idx_chore_user"` // The user this assignee is for
 }
 type ChoreHistory struct {
-	ID          int                `json:"id" gorm:"primary_key"`                             // Unique identifier
-	ChoreID     int                `json:"choreId" gorm:"column:chore_id"`                    // The chore this history is for
-	PerformedAt *time.Time         `json:"performedAt" gorm:"column:performed_at"`            // When the chore was performed (completed or skipped)
-	CompletedBy int                `json:"completedBy" gorm:"column:completed_by"`            // Who completed the chore
-	AssignedTo  *int               `json:"assignedTo" gorm:"column:assigned_to"`              // Who the chore was assigned to
-	Note        *string            `json:"notes" gorm:"column:notes"`                         // Notes about the chore
-	DueDate     *time.Time         `json:"dueDate" gorm:"column:due_date"`                    // When the chore was due
-	UpdatedAt   *time.Time         `json:"updatedAt" gorm:"column:updated_at"`                            // When the record was last updated
+	ID          int                `json:"id" gorm:"primary_key"`                                       // Unique identifier
+	ChoreID     int                `json:"choreId" gorm:"column:chore_id"`                              // The chore this history is for
+	PerformedAt *time.Time         `json:"performedAt" gorm:"column:performed_at"`                      // When the chore was performed (completed or skipped)
+	CompletedBy int                `json:"completedBy" gorm:"column:completed_by"`                      // Who completed the chore
+	AssignedTo  *int               `json:"assignedTo" gorm:"column:assigned_to"`                        // Who the chore was assigned to
+	Note        *string            `json:"notes" gorm:"column:notes"`                                   // Notes about the chore
+	DueDate     *time.Time         `json:"dueDate" gorm:"column:due_date"`                              // When the chore was due
+	UpdatedAt   *time.Time         `json:"updatedAt" gorm:"column:updated_at"`                          // When the record was last updated
 	CreatedAt   time.Time          `json:"createdAt" gorm:"column:created_at;autoCreateTime;<-:create"` // When the record was created (immutable after insert)
-	Status      ChoreHistoryStatus `json:"status" gorm:"column:status"`                       // Status of the chore (1=completed, 2=skipped)
-	Points      *int               `json:"points,omitempty" gorm:"column:points"`             // Points for completing the chore
-	Duration    *int               `json:"duration,omitempty" gorm:"<-:false;-:migration"`    // Duration in seconds calculated from query (read-only, no DB column)
+	Status      ChoreHistoryStatus `json:"status" gorm:"column:status"`                                 // Status of the chore (1=completed, 2=skipped)
+	Points      *int               `json:"points,omitempty" gorm:"column:points"`                       // Points for completing the chore
+	Duration    *int               `json:"duration,omitempty" gorm:"<-:false;-:migration"`              // Duration in seconds calculated from query (read-only, no DB column)
 	SyncVersion int64              `json:"syncVersion" gorm:"column:sync_version;not null;default:0"`
 }
 

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -188,6 +188,7 @@ type ChoreDetail struct {
 	TimerUpdatedAt      *time.Time         `json:"timerUpdatedAt" gorm:"column:timer_updated_at"` // When the chore was last started
 	ProjectID           *int               `json:"projectId,omitempty" gorm:"column:project_id"`
 	IsActive            bool               `json:"isActive" gorm:"column:is_active"`
+	SyncVersion         int64              `json:"syncVersion" gorm:"column:sync_version"`
 }
 
 type ChoreLabels struct {

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -14,6 +14,7 @@ import (
 	syncModel "donetick.com/core/internal/sync/model"
 	"donetick.com/core/logging"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type ChoreRepository struct {
@@ -33,12 +34,17 @@ func NewChoreRepository(db *gorm.DB, cfg *config.Config) *ChoreRepository {
 	return &ChoreRepository{db: db, dbType: cfg.Database.Type}
 }
 
-// privacyPredicate returns the WHERE clause that enforces chore visibility rules.
-// A chore is visible to a user if:
+// privacyPredicate returns a GORM clause expression that enforces chore visibility
+// rules using bound parameters (no string interpolation). A chore is visible if:
 //   - It is not private, OR
 //   - It is private AND (the user created it OR the user is assigned to it)
-func privacyPredicate(userID int) string {
-	return fmt.Sprintf(`((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = %d OR chore_assignees.user_id = %d)))`, userID, userID)
+//
+// Use as: db.Where(privacyPredicate(userID))
+func privacyPredicate(userID int) clause.Expr {
+	return clause.Expr{
+		SQL:  `((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))`,
+		Vars: []interface{}{userID, userID},
+	}
 }
 
 func (r *ChoreRepository) nextSyncVersionWithDB(ctx context.Context, db *gorm.DB, circleID int) (int64, error) {
@@ -178,7 +184,8 @@ func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int,
 		Preload("Assignees").
 		Preload("LabelsV2").
 		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
-		Where("chores.circle_id = ? AND "+privacyPredicate(userID), circleID).
+		Where("chores.circle_id = ?", circleID).
+		Where(privacyPredicate(userID)).
 		Group("chores.id")
 
 	if !includeArchived {
@@ -207,7 +214,8 @@ func (r *ChoreRepository) GetArchivedChores(c context.Context, circleID int, use
 		Preload("Assignees").
 		Preload("LabelsV2").
 		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
-		Where("chores.circle_id = ? AND "+privacyPredicate(userID), circleID).
+		Where("chores.circle_id = ?", circleID).
+		Where(privacyPredicate(userID)).
 		Where("is_active = ?", false).
 		Group("chores.id").
 		Order("next_due_date asc").
@@ -935,12 +943,17 @@ func (r *ChoreRepository) CreateTimeSession(c context.Context, chore *chModel.Ch
 	log := logging.FromContext(c)
 	var timeSession *chModel.TimeSession
 	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+		syncVersion, err := r.nextSyncVersionWithDB(c, tx, chore.CircleID)
+		if err != nil {
+			return fmt.Errorf("failed to allocate sync version: %w", err)
+		}
 		ch := &chModel.ChoreHistory{
 			ChoreID:     chore.ID,
 			CompletedBy: userID,
 			AssignedTo:  chore.AssignedTo,
 			DueDate:     chore.NextDueDate,
 			Status:      chModel.ChoreHistoryStatusStarted,
+			SyncVersion: syncVersion,
 		}
 
 		if err := tx.Create(ch).Error; err != nil {

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -36,8 +36,15 @@ func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (in
 }
 
 func (r *ChoreRepository) insertTombstone(ctx context.Context, tx *gorm.DB, circleID int, entityID int) error {
-	version, err := r.nextSyncVersion(ctx, circleID)
-	if err != nil {
+	// Use tx (not r.db) so the version increment and tombstone insert are atomic.
+	var version int64
+	if err := tx.WithContext(ctx).Raw(`
+		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
+		VALUES (?, ?, 1)
+		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + 1
+		RETURNING max_version`,
+		circleID, syncModel.EntityTypeChore,
+	).Scan(&version).Error; err != nil {
 		return err
 	}
 	return tx.WithContext(ctx).Create(&syncModel.Tombstone{
@@ -84,14 +91,28 @@ func (r *ChoreRepository) UpdateChoreFields(ctx context.Context, choreID int, fi
 	return r.db.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(fields).Error
 }
 
+// nextSyncVersionRange atomically reserves a contiguous block of `count` sync
+// versions for a circle and returns the first (lowest) version in the range.
+func (r *ChoreRepository) nextSyncVersionRange(ctx context.Context, circleID int, count int) (int64, error) {
+	var endVersion int64
+	err := r.db.WithContext(ctx).Raw(`
+		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
+		VALUES (?, ?, ?)
+		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + ?
+		RETURNING max_version`,
+		circleID, syncModel.EntityTypeChore, count, count,
+	).Scan(&endVersion).Error
+	return endVersion - int64(count) + 1, err
+}
+
 func (r *ChoreRepository) UpdateChores(c context.Context, chores []*chModel.Chore) error {
 	if len(chores) > 0 {
-		nextVersion, err := r.nextSyncVersion(c, chores[0].CircleID)
+		startVersion, err := r.nextSyncVersionRange(c, chores[0].CircleID, len(chores))
 		if err != nil {
 			return err
 		}
 		for i, ch := range chores {
-			ch.SyncVersion = nextVersion + int64(i)
+			ch.SyncVersion = startVersion + int64(i)
 		}
 	}
 	return r.db.WithContext(c).Save(&chores).Error

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -21,8 +21,24 @@ type ChoreRepository struct {
 	dbType string
 }
 
+// SyncOptions configures sync-aware queries for chores and histories.
+// When SyncVersion is nil, the query is NOT filtered by sync version (normal operation).
+// When SyncVersion is set, the query returns only records with sync_version > *SyncVersion, in ascending order.
+type SyncOptions struct {
+	SyncVersion *int64 // nil = no sync filtering; pointer = filter by version
+	Limit       int    // Number of records to fetch (used with sync filtering)
+}
+
 func NewChoreRepository(db *gorm.DB, cfg *config.Config) *ChoreRepository {
 	return &ChoreRepository{db: db, dbType: cfg.Database.Type}
+}
+
+// privacyPredicate returns the WHERE clause that enforces chore visibility rules.
+// A chore is visible to a user if:
+//   - It is not private, OR
+//   - It is private AND (the user created it OR the user is assigned to it)
+func privacyPredicate(userID int) string {
+	return fmt.Sprintf(`((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = %d OR chore_assignees.user_id = %d)))`, userID, userID)
 }
 
 func (r *ChoreRepository) nextSyncVersionWithDB(ctx context.Context, db *gorm.DB, circleID int) (int64, error) {
@@ -152,13 +168,34 @@ func (r *ChoreRepository) GetChore(c context.Context, choreID int, userID int, c
 	return &chore, nil
 }
 
-func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int, includeArchived bool) ([]*chModel.Chore, error) {
+// GetChores retrieves chores for a user in a circle, respecting privacy and optionally filtered by sync version.
+// If syncOptions is nil or syncOptions.SyncVersion is nil, returns all visible chores ordered by next_due_date.
+// If syncOptions.SyncVersion is set, returns only chores with sync_version > *SyncVersion, ordered by sync_version.
+func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int, includeArchived bool, syncOptions *SyncOptions) ([]*chModel.Chore, error) {
 	var chores []*chModel.Chore
-	query := r.db.WithContext(c).Preload("Assignees").Preload("LabelsV2").Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").Where("chores.circle_id = ? AND ((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))", circleID, userID, userID).Group("chores.id").Order("next_due_date asc")
+
+	query := r.db.WithContext(c).
+		Preload("Assignees").
+		Preload("LabelsV2").
+		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
+		Where("chores.circle_id = ? AND "+privacyPredicate(userID), circleID).
+		Group("chores.id")
+
 	if !includeArchived {
 		query = query.Where("chores.is_active = ?", true)
 	}
-	if err := query.Find(&chores, "circle_id = ?", circleID).Error; err != nil {
+
+	// Sync-specific filtering if provided.
+	if syncOptions != nil && syncOptions.SyncVersion != nil {
+		query = query.Where("chores.sync_version > ?", *syncOptions.SyncVersion).
+			Order("chores.sync_version asc").
+			Limit(syncOptions.Limit + 1)
+	} else {
+		// Normal ordering when not syncing.
+		query = query.Order("next_due_date asc")
+	}
+
+	if err := query.Find(&chores).Error; err != nil {
 		return nil, err
 	}
 	return chores, nil
@@ -166,7 +203,15 @@ func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int,
 
 func (r *ChoreRepository) GetArchivedChores(c context.Context, circleID int, userID int) ([]*chModel.Chore, error) {
 	var chores []*chModel.Chore
-	if err := r.db.WithContext(c).Preload("Assignees").Preload("LabelsV2").Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").Where("chores.circle_id = ? AND ((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))", circleID, userID, userID).Group("chores.id").Order("next_due_date asc").Find(&chores, "circle_id = ? AND is_active = ?", circleID, false).Error; err != nil {
+	if err := r.db.WithContext(c).
+		Preload("Assignees").
+		Preload("LabelsV2").
+		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
+		Where("chores.circle_id = ? AND "+privacyPredicate(userID), circleID).
+		Where("is_active = ?", false).
+		Group("chores.id").
+		Order("next_due_date asc").
+		Find(&chores).Error; err != nil {
 		return nil, err
 	}
 	return chores, nil
@@ -989,21 +1034,6 @@ func (r *ChoreRepository) DeleteTimeSession(c context.Context, sessionID int, ch
 
 }
 
-// GetChoreChangesSince returns all chores (including soft-deleted) with sync_version > since, scoped to a circle.
-func (r *ChoreRepository) GetChoreChangesSince(c context.Context, circleID int, since int64, limit int) ([]*chModel.Chore, error) {
-	var chores []*chModel.Chore
-	if err := r.db.WithContext(c).
-		Preload("Assignees").
-		Preload("LabelsV2").
-		Where("circle_id = ? AND sync_version > ?", circleID, since).
-		Order("sync_version asc").
-		Limit(limit).
-		Find(&chores).Error; err != nil {
-		return nil, err
-	}
-	return chores, nil
-}
-
 // GetTombstonesSince returns tombstones for a given circle and entity type with sync_version > since.
 func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, since int64, limit int) ([]*syncModel.Tombstone, error) {
 	var tombstones []*syncModel.Tombstone
@@ -1019,7 +1049,9 @@ func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, en
 	return tombstones, nil
 }
 
-// GetChoreHistoryChangesSince returns chore history records for a circle with sync_version > since.
+// GetChoreHistoryChangesSince is deprecated. Use GetChoresHistoryByCircle with syncOptions instead.
+// Kept for backward compatibility but should not be used in new code.
+// WARNING: This method does NOT apply privacy filters, leaking private chore histories to all circle members.
 func (r *ChoreRepository) GetChoreHistoryChangesSince(c context.Context, circleID int, since int64, limit int) ([]*chModel.ChoreHistory, error) {
 	var histories []*chModel.ChoreHistory
 	if err := r.db.WithContext(c).
@@ -1031,6 +1063,38 @@ func (r *ChoreRepository) GetChoreHistoryChangesSince(c context.Context, circleI
 		Order("chore_histories.sync_version asc").
 		Limit(limit).
 		Find(&histories).Error; err != nil {
+		return nil, err
+	}
+	return histories, nil
+}
+
+// GetChoresHistoryByCircle retrieves chore histories for a circle, respecting privacy and optionally filtered by sync version.
+// A history is visible if the user can see the associated chore (privacy rules apply).
+// If syncOptions is nil or syncOptions.SyncVersion is nil, returns all visible histories ordered by performed_at DESC.
+// If syncOptions.SyncVersion is set, returns only histories with sync_version > *SyncVersion, ordered by sync_version ASC.
+func (r *ChoreRepository) GetChoresHistoryByCircle(c context.Context, circleID int, userID int, syncOptions *SyncOptions) ([]*chModel.ChoreHistory, error) {
+	var histories []*chModel.ChoreHistory
+
+	query := r.db.WithContext(c).
+		Table("chore_histories").
+		Select("chore_histories.*, time_sessions.duration").
+		Joins("JOIN chores ON chores.id = chore_histories.chore_id").
+		Joins("LEFT JOIN time_sessions ON time_sessions.chore_history_id = chore_histories.id").
+		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
+		Where("chores.circle_id = ?", circleID).
+		Where(privacyPredicate(userID))
+
+	// Sync-specific filtering if provided.
+	if syncOptions != nil && syncOptions.SyncVersion != nil {
+		query = query.Where("chore_histories.sync_version > ?", *syncOptions.SyncVersion).
+			Order("chore_histories.sync_version asc").
+			Limit(syncOptions.Limit + 1)
+	} else {
+		// Normal ordering when not syncing.
+		query = query.Order("chore_histories.performed_at desc, chore_histories.updated_at desc")
+	}
+
+	if err := query.Find(&histories).Error; err != nil {
 		return nil, err
 	}
 	return histories, nil

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -854,10 +854,14 @@ func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, userID in
 	if err != nil {
 		return err
 	}
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", choreID, userID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ? AND circle_id = ?", choreID, userID, circleID).Updates(map[string]interface{}{
 		"is_active":    false,
 		"sync_version": nextVersion,
-	}).Error
+	})
+	if result.RowsAffected == 0 {
+		return errors.New("chore not found or not authorized")
+	}
+	return result.Error
 }
 
 func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, userID int, circleID int) error {
@@ -865,10 +869,14 @@ func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, userID 
 	if err != nil {
 		return err
 	}
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", choreID, userID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ? AND circle_id = ?", choreID, userID, circleID).Updates(map[string]interface{}{
 		"is_active":    true,
 		"sync_version": nextVersion,
-	}).Error
+	})
+	if result.RowsAffected == 0 {
+		return errors.New("chore not found or not authorized")
+	}
+	return result.Error
 }
 
 func (r *ChoreRepository) GetChoresHistoryByUserID(c context.Context, userID int, circleID int, days int, includeCircle bool) ([]*chModel.ChoreHistory, error) {
@@ -901,7 +909,7 @@ func (r *ChoreRepository) UpdateChoreStatus(c context.Context, choreID int, stat
 	if err != nil {
 		return err
 	}
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 		"status":       status,
 		"sync_version": nextVersion,
 	}).Error
@@ -1047,25 +1055,6 @@ func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, en
 		return nil, err
 	}
 	return tombstones, nil
-}
-
-// GetChoreHistoryChangesSince is deprecated. Use GetChoresHistoryByCircle with syncOptions instead.
-// Kept for backward compatibility but should not be used in new code.
-// WARNING: This method does NOT apply privacy filters, leaking private chore histories to all circle members.
-func (r *ChoreRepository) GetChoreHistoryChangesSince(c context.Context, circleID int, since int64, limit int) ([]*chModel.ChoreHistory, error) {
-	var histories []*chModel.ChoreHistory
-	if err := r.db.WithContext(c).
-		Table("chore_histories").
-		Select("chore_histories.*, time_sessions.duration").
-		Joins("JOIN chores ON chores.id = chore_histories.chore_id").
-		Joins("LEFT JOIN time_sessions ON time_sessions.chore_history_id = chore_histories.id").
-		Where("chores.circle_id = ? AND chore_histories.sync_version > ?", circleID, since).
-		Order("chore_histories.sync_version asc").
-		Limit(limit).
-		Find(&histories).Error; err != nil {
-		return nil, err
-	}
-	return histories, nil
 }
 
 // GetChoresHistoryByCircle retrieves chore histories for a circle, respecting privacy and optionally filtered by sync version.

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -261,7 +261,7 @@ func (r *ChoreRepository) SoftDelete(c context.Context, id int, userID int, circ
 	if err != nil {
 		return err
 	}
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", id, userID).Updates(map[string]interface{}{
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ? AND circle_id = ?", id, userID, circleID).Updates(map[string]interface{}{
 		"is_active":    false,
 		"sync_version": nextVersion,
 	}).Error

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -209,6 +209,7 @@ func (r *ChoreRepository) SetChorePendingApproval(c context.Context, chore *chMo
 			return err
 		}
 
+		ch.SyncVersion = nextVersion
 		if err := tx.Save(ch).Error; err != nil {
 			return err
 		}
@@ -267,6 +268,7 @@ func (r *ChoreRepository) ApproveChore(c context.Context, chore *chModel.Chore, 
 
 		// Update status to completed
 		history.Status = chModel.ChoreHistoryStatusCompleted
+		history.SyncVersion = nextVersion
 
 		// Update UserCircle Points if applicable
 		if applyPoints && chore.Points != nil && *chore.Points > 0 {
@@ -316,6 +318,7 @@ func (r *ChoreRepository) RejectChore(c context.Context, choreID int, circleID i
 
 		// Update status to rejected
 		history.Status = chModel.ChoreHistoryStatusRejected
+		history.SyncVersion = nextVersion
 
 		// Save the updated history
 		if err := tx.Save(&history).Error; err != nil {
@@ -386,6 +389,7 @@ func (r *ChoreRepository) CompleteChore(c context.Context, chore *chModel.Chore,
 				return err
 			}
 		}
+		ch.SyncVersion = nextVersion
 		// Perform the update operation once, using the prepared updates map.
 		if err := tx.Model(&chModel.Chore{}).Where("id = ?", chore.ID).Updates(choreUpdates).Error; err != nil {
 			return err
@@ -460,6 +464,7 @@ func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, use
 			return err
 		}
 
+		ch.SyncVersion = nextVersion
 		// Perform the update operation once, using the prepared updates map.
 		if err := tx.Model(&chModel.Chore{}).Where("id = ?", chore.ID).Updates(choreUpdates).Error; err != nil {
 			return err
@@ -546,7 +551,11 @@ func (r *ChoreRepository) UpdateLatestChoreHistory(c context.Context, choreID in
 	return nil
 }
 
-func (r *ChoreRepository) DeleteChoreHistory(c context.Context, historyID int) error {
+func (r *ChoreRepository) DeleteChoreHistory(c context.Context, historyID int, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
 	// create transaction and delete all the chore timer assiociated with the chore history then delete the chore history
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		if err := tx.WithContext(c).Where("chore_history_id = ?", historyID).Delete(&chModel.TimeSession{}).Error; err != nil {
@@ -556,9 +565,14 @@ func (r *ChoreRepository) DeleteChoreHistory(c context.Context, historyID int) e
 		if err := tx.WithContext(c).Delete(&chModel.ChoreHistory{}, historyID).Error; err != nil {
 			return fmt.Errorf("failed to delete chore history: %w", err)
 		}
-		return nil
+		// Record tombstone so clients can remove it during sync
+		return tx.WithContext(c).Create(&syncModel.Tombstone{
+			CircleID:    circleID,
+			EntityType:  syncModel.EntityTypeChoreHistory,
+			EntityID:    historyID,
+			SyncVersion: nextVersion,
+		}).Error
 	})
-
 }
 
 func (r *ChoreRepository) UpdateChoreAssignees(c context.Context, assignees []*chModel.ChoreAssignees) error {
@@ -899,15 +913,35 @@ func (r *ChoreRepository) GetChoreChangesSince(c context.Context, circleID int, 
 }
 
 // GetTombstonesSince returns tombstones for a given circle and entity type with sync_version > since.
-func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, since int64) ([]*syncModel.Tombstone, error) {
+func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, since int64, limit int) ([]*syncModel.Tombstone, error) {
 	var tombstones []*syncModel.Tombstone
-	if err := r.db.WithContext(c).
+	query := r.db.WithContext(c).
 		Where("circle_id = ? AND entity_type = ? AND sync_version > ?", circleID, entityType, since).
-		Order("sync_version asc").
-		Find(&tombstones).Error; err != nil {
+		Order("sync_version asc")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&tombstones).Error; err != nil {
 		return nil, err
 	}
 	return tombstones, nil
+}
+
+// GetChoreHistoryChangesSince returns chore history records for a circle with sync_version > since.
+func (r *ChoreRepository) GetChoreHistoryChangesSince(c context.Context, circleID int, since int64, limit int) ([]*chModel.ChoreHistory, error) {
+	var histories []*chModel.ChoreHistory
+	if err := r.db.WithContext(c).
+		Table("chore_histories").
+		Select("chore_histories.*, time_sessions.duration").
+		Joins("JOIN chores ON chores.id = chore_histories.chore_id").
+		Joins("LEFT JOIN time_sessions ON time_sessions.chore_history_id = chore_histories.id").
+		Where("chores.circle_id = ? AND chore_histories.sync_version > ?", circleID, since).
+		Order("chore_histories.sync_version asc").
+		Limit(limit).
+		Find(&histories).Error; err != nil {
+		return nil, err
+	}
+	return histories, nil
 }
 
 // GetUserLastChoreAction gets the user's most recent action on a chore (within time limit)

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -399,7 +399,7 @@ func (r *ChoreRepository) RejectChore(c context.Context, choreID int, circleID i
 	}
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		// Reset chore status to normal
-		if err := tx.Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+		if err := tx.Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 			"status":       chModel.ChoreStatusNoStatus,
 			"sync_version": nextVersion,
 		}).Error; err != nil {
@@ -514,7 +514,7 @@ func (r *ChoreRepository) CompleteChore(c context.Context, chore *chModel.Chore,
 	return err
 }
 
-func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, userID int, dueDate *time.Time, nextAssignedTo *int) error {
+func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, userID int, dueDate *time.Time, nextAssignedTo *int, skippedAt *time.Time) error {
 	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
 	if err != nil {
 		return err
@@ -539,12 +539,15 @@ func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, use
 			First(&existingHistory).Error
 
 		var ch *chModel.ChoreHistory
-		skippedAt := time.Now().UTC()
+		effectiveSkippedAt := time.Now().UTC()
+		if skippedAt != nil {
+			effectiveSkippedAt = skippedAt.UTC()
+		}
 
 		switch {
 		case err == nil && existingHistory.PerformedAt != nil:
 			// Update existing history record
-			existingHistory.PerformedAt = &skippedAt
+			existingHistory.PerformedAt = &effectiveSkippedAt
 			existingHistory.Note = nil
 			existingHistory.Status = chModel.ChoreHistoryStatusSkipped
 			ch = &existingHistory
@@ -552,7 +555,7 @@ func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, use
 			// Create a new chore history record for the skipped chore
 			ch = &chModel.ChoreHistory{
 				ChoreID:     chore.ID,
-				PerformedAt: &skippedAt,
+				PerformedAt: &effectiveSkippedAt,
 				CompletedBy: userID,
 				AssignedTo:  chore.AssignedTo,
 				DueDate:     chore.NextDueDate,
@@ -812,6 +815,7 @@ func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, cir
 		chores.completion_window,
 		chores.status,
 		chores.is_active,
+		chores.sync_version,
 		CAST(MAX(time_sessions.duration) AS INTEGER) as duration,
 		time_sessions.start_time as start_time,
 		time_sessions.updated_at as timer_updated_at,
@@ -904,15 +908,16 @@ func (r *ChoreRepository) GetChoresHistoryByUserID(c context.Context, userID int
 	return chores, nil
 }
 
-func (r *ChoreRepository) UpdateChoreStatus(c context.Context, choreID int, status chModel.Status, circleID int) error {
+func (r *ChoreRepository) UpdateChoreStatus(c context.Context, choreID int, status chModel.Status, circleID int) (int64, error) {
 	nextVersion, err := r.nextSyncVersion(c, circleID)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 		"status":       status,
 		"sync_version": nextVersion,
-	}).Error
+	})
+	return nextVersion, result.Error
 }
 
 func (r *ChoreRepository) GetActiveTimeSession(c context.Context, choreID int) (*chModel.TimeSession, error) {

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -9,8 +9,7 @@ import (
 	config "donetick.com/core/config"
 	chModel "donetick.com/core/internal/chore/model"
 	cModel "donetick.com/core/internal/circle/model"
-	storageModel "donetick.com/core/internal/storage/model"
-	stModel "donetick.com/core/internal/subtask/model"
+	syncModel "donetick.com/core/internal/sync/model"
 	"donetick.com/core/logging"
 	"gorm.io/gorm"
 )
@@ -24,26 +23,85 @@ func NewChoreRepository(db *gorm.DB, cfg *config.Config) *ChoreRepository {
 	return &ChoreRepository{db: db, dbType: cfg.Database.Type}
 }
 
+func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (int64, error) {
+	var version int64
+	err := r.db.WithContext(ctx).Raw(`
+		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
+		VALUES (?, ?, 1)
+		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + 1
+		RETURNING max_version`,
+		circleID, syncModel.EntityTypeChore,
+	).Scan(&version).Error
+	return version, err
+}
+
+func (r *ChoreRepository) insertTombstone(ctx context.Context, tx *gorm.DB, circleID int, entityID int) error {
+	version, err := r.nextSyncVersion(ctx, circleID)
+	if err != nil {
+		return err
+	}
+	return tx.WithContext(ctx).Create(&syncModel.Tombstone{
+		CircleID:    circleID,
+		EntityType:  syncModel.EntityTypeChore,
+		EntityID:    entityID,
+		SyncVersion: version,
+	}).Error
+}
+
 func (r *ChoreRepository) UpsertChore(c context.Context, chore *chModel.Chore) error {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	chore.SyncVersion = nextVersion
 	return r.db.WithContext(c).Model(&chore).Save(chore).Error
 }
-func (r *ChoreRepository) UpdateChorePriority(c context.Context, userID int, choreID int, priority int) error {
-	var affectedRows int64
-	r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Update("priority", priority).Count(&affectedRows)
-	if affectedRows == 0 {
+func (r *ChoreRepository) UpdateChorePriority(c context.Context, userID int, choreID int, priority int, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+		"priority":     priority,
+		"sync_version": nextVersion,
+	})
+	if result.RowsAffected == 0 {
 		return errors.New("no rows affected")
 	}
-	return nil
+	return result.Error
 }
 
 func (r *ChoreRepository) UpdateChoreFields(ctx context.Context, choreID int, fields map[string]interface{}) error {
+	var chore chModel.Chore
+	if err := r.db.WithContext(ctx).Select("circle_id").First(&chore, choreID).Error; err != nil {
+		return err
+	}
+	nextVersion, err := r.nextSyncVersion(ctx, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	fields["sync_version"] = nextVersion
 	return r.db.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(fields).Error
 }
 
 func (r *ChoreRepository) UpdateChores(c context.Context, chores []*chModel.Chore) error {
+	if len(chores) > 0 {
+		nextVersion, err := r.nextSyncVersion(c, chores[0].CircleID)
+		if err != nil {
+			return err
+		}
+		for i, ch := range chores {
+			ch.SyncVersion = nextVersion + int64(i)
+		}
+	}
 	return r.db.WithContext(c).Save(&chores).Error
 }
 func (r *ChoreRepository) CreateChore(c context.Context, chore *chModel.Chore) (int, error) {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return 0, err
+	}
+	chore.SyncVersion = nextVersion
 	if err := r.db.WithContext(c).Create(chore).Error; err != nil {
 		return 0, err
 	}
@@ -87,39 +145,27 @@ func (r *ChoreRepository) GetArchivedChores(c context.Context, circleID int, use
 }
 
 func (r *ChoreRepository) DeleteChore(c context.Context, id int) error {
+	var chore chModel.Chore
+	if err := r.db.WithContext(c).Select("id, circle_id").First(&chore, id).Error; err != nil {
+		return err
+	}
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("chore_id = ?", id).Delete(&chModel.ChoreAssignees{}).Error; err != nil {
-			return err
-		}
-		if err := tx.Where("chore_id = ?", id).Delete(&chModel.TimeSession{}).Error; err != nil {
-			return err
-		}
-		if err := tx.Delete(&chModel.ChoreHistory{}, "chore_id = ?", id).Error; err != nil {
-			return err
-		}
-		// subtask if exists:
-		if err := tx.Where("chore_id = ?", id).Delete(&stModel.SubTask{}).Error; err != nil {
-			return err
-		}
 		if err := tx.Delete(&chModel.Chore{}, id).Error; err != nil {
 			return err
 		}
-		// Delete all subtasks associated with the chore
-		if err := tx.Where("chore_id = ?", id).Delete(&stModel.SubTask{}).Error; err != nil {
-			return err
-		}
-		// Delete all chore storage files associated with the chore:
-		if err := tx.Where("entity_type = ? AND entity_id = ?", storageModel.EntityTypeChoreDescription, id).Delete(&storageModel.StorageFile{}).Error; err != nil {
-			return err
-		}
-
-		return nil
+		return r.insertTombstone(c, tx, chore.CircleID, id)
 	})
 }
 
-func (r *ChoreRepository) SoftDelete(c context.Context, id int, userID int) error {
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", id).Where("created_by = ? ", userID).Update("is_active", false).Error
-
+func (r *ChoreRepository) SoftDelete(c context.Context, id int, userID int, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", id, userID).Updates(map[string]interface{}{
+		"is_active":    false,
+		"sync_version": nextVersion,
+	}).Error
 }
 
 func (r *ChoreRepository) IsChoreOwner(c context.Context, choreID int, userID int) error {
@@ -129,7 +175,11 @@ func (r *ChoreRepository) IsChoreOwner(c context.Context, choreID int, userID in
 }
 
 func (r *ChoreRepository) SetChorePendingApproval(c context.Context, chore *chModel.Chore, note *string, userID int, completedDate *time.Time) error {
-	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	err = r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		// Look for existing chore history with start or pause status
 		var existingHistory chModel.ChoreHistory
 		err := tx.Where("chore_id = ? AND status = ? ",
@@ -164,7 +214,10 @@ func (r *ChoreRepository) SetChorePendingApproval(c context.Context, chore *chMo
 		}
 
 		// Set chore status to pending approval
-		if err := tx.Model(&chModel.Chore{}).Where("id = ?", chore.ID).Update("status", chModel.ChoreStatusPendingApproval).Error; err != nil {
+		if err := tx.Model(&chModel.Chore{}).Where("id = ?", chore.ID).Updates(map[string]interface{}{
+			"status":       chModel.ChoreStatusPendingApproval,
+			"sync_version": nextVersion,
+		}).Error; err != nil {
 			return err
 		}
 
@@ -186,10 +239,15 @@ func (r *ChoreRepository) SetChorePendingApproval(c context.Context, chore *chMo
 }
 
 func (r *ChoreRepository) ApproveChore(c context.Context, chore *chModel.Chore, adminUserID int, dueDate *time.Time, nextAssignedTo *int, applyPoints bool) error {
-	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	err = r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		choreUpdates := map[string]interface{}{}
 		choreUpdates["next_due_date"] = dueDate
 		choreUpdates["status"] = chModel.ChoreStatusNoStatus
+		choreUpdates["sync_version"] = nextVersion
 
 		if dueDate != nil {
 			choreUpdates["assigned_to"] = nextAssignedTo
@@ -233,10 +291,17 @@ func (r *ChoreRepository) ApproveChore(c context.Context, chore *chModel.Chore, 
 	return err
 }
 
-func (r *ChoreRepository) RejectChore(c context.Context, choreID int, rejectionNote *string) error {
+func (r *ChoreRepository) RejectChore(c context.Context, choreID int, circleID int, rejectionNote *string) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		// Reset chore status to normal
-		if err := tx.Model(&chModel.Chore{}).Where("id = ?", choreID).Update("status", chModel.ChoreStatusNoStatus).Error; err != nil {
+		if err := tx.Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+			"status":       chModel.ChoreStatusNoStatus,
+			"sync_version": nextVersion,
+		}).Error; err != nil {
 			return err
 		}
 
@@ -262,11 +327,16 @@ func (r *ChoreRepository) RejectChore(c context.Context, choreID int, rejectionN
 }
 
 func (r *ChoreRepository) CompleteChore(c context.Context, chore *chModel.Chore, note *string, userID int, dueDate *time.Time, completedDate *time.Time, nextAssignedTo *int, applyPoints bool) error {
-	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	err = r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 
 		choreUpdates := map[string]interface{}{}
 		choreUpdates["next_due_date"] = dueDate
 		choreUpdates["status"] = chModel.ChoreStatusNoStatus
+		choreUpdates["sync_version"] = nextVersion
 
 		switch {
 		case dueDate != nil:
@@ -342,10 +412,15 @@ func (r *ChoreRepository) CompleteChore(c context.Context, chore *chModel.Chore,
 }
 
 func (r *ChoreRepository) SkipChore(c context.Context, chore *chModel.Chore, userID int, dueDate *time.Time, nextAssignedTo *int) error {
-	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	err = r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		choreUpdates := map[string]interface{}{}
 		choreUpdates["next_due_date"] = dueDate
 		choreUpdates["status"] = chModel.ChoreStatusNoStatus
+		choreUpdates["sync_version"] = nextVersion
 
 		if dueDate != nil {
 			choreUpdates["assigned_to"] = nextAssignedTo
@@ -596,19 +671,21 @@ func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, cir
         COUNT(chore_histories.id) as total_completed`).
 		Joins("LEFT JOIN chore_histories ON chores.id = chore_histories.chore_id").
 		Joins(`LEFT JOIN (
-        SELECT 
-            chore_id, 
-            assigned_to AS last_assigned_to, 
+        SELECT
+            chore_id,
+            assigned_to AS last_assigned_to,
             performed_at AS last_completed_date,
 			completed_by AS last_completed_by,
 			notes
-			
+
         FROM chore_histories
         WHERE (chore_id, performed_at) IN (
             SELECT chore_id, MAX(performed_at)
             FROM chore_histories
+            WHERE status IN (1, 2, 3, 4)
             GROUP BY chore_id
         )
+        AND status IN (1, 2, 3, 4)
     ) AS recent_history ON chores.id = recent_history.chore_id`).
 		Joins("LEFT JOIN time_sessions ON chores.id = time_sessions.chore_id AND time_sessions.status < ?", chModel.TimeSessionStatusCompleted).
 		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
@@ -621,12 +698,26 @@ func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, cir
 	return &choreDetail, nil
 }
 
-func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, userID int) error {
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? and created_by = ?", choreID, userID).Update("is_active", false).Error
+func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, userID int, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", choreID, userID).Updates(map[string]interface{}{
+		"is_active":    false,
+		"sync_version": nextVersion,
+	}).Error
 }
 
-func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, userID int) error {
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? and created_by = ?", choreID, userID).Update("is_active", true).Error
+func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, userID int, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ?", choreID, userID).Updates(map[string]interface{}{
+		"is_active":    true,
+		"sync_version": nextVersion,
+	}).Error
 }
 
 func (r *ChoreRepository) GetChoresHistoryByUserID(c context.Context, userID int, circleID int, days int, includeCircle bool) ([]*chModel.ChoreHistory, error) {
@@ -654,8 +745,15 @@ func (r *ChoreRepository) GetChoresHistoryByUserID(c context.Context, userID int
 	return chores, nil
 }
 
-func (r *ChoreRepository) UpdateChoreStatus(c context.Context, choreID int, status chModel.Status) error {
-	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Update("status", status).Error
+func (r *ChoreRepository) UpdateChoreStatus(c context.Context, choreID int, status chModel.Status, circleID int) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+		"status":       status,
+		"sync_version": nextVersion,
+	}).Error
 }
 
 func (r *ChoreRepository) GetActiveTimeSession(c context.Context, choreID int) (*chModel.TimeSession, error) {
@@ -785,6 +883,33 @@ func (r *ChoreRepository) DeleteTimeSession(c context.Context, sessionID int, ch
 
 }
 
+// GetChoreChangesSince returns all chores (including soft-deleted) with sync_version > since, scoped to a circle.
+func (r *ChoreRepository) GetChoreChangesSince(c context.Context, circleID int, since int64, limit int) ([]*chModel.Chore, error) {
+	var chores []*chModel.Chore
+	if err := r.db.WithContext(c).
+		Preload("Assignees").
+		Preload("LabelsV2").
+		Where("circle_id = ? AND sync_version > ?", circleID, since).
+		Order("sync_version asc").
+		Limit(limit).
+		Find(&chores).Error; err != nil {
+		return nil, err
+	}
+	return chores, nil
+}
+
+// GetTombstonesSince returns tombstones for a given circle and entity type with sync_version > since.
+func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, since int64) ([]*syncModel.Tombstone, error) {
+	var tombstones []*syncModel.Tombstone
+	if err := r.db.WithContext(c).
+		Where("circle_id = ? AND entity_type = ? AND sync_version > ?", circleID, entityType, since).
+		Order("sync_version asc").
+		Find(&tombstones).Error; err != nil {
+		return nil, err
+	}
+	return tombstones, nil
+}
+
 // GetUserLastChoreAction gets the user's most recent action on a chore (within time limit)
 func (r *ChoreRepository) GetUserLastChoreAction(c context.Context, choreID int, userID int, timeLimit time.Duration) (*chModel.ChoreHistory, error) {
 	var history chModel.ChoreHistory
@@ -833,7 +958,11 @@ func (r *ChoreRepository) GetChoreStateBefore(c context.Context, choreID int, be
 }
 
 // UndoChoreAction undoes a chore action by restoring previous state and removing the history entry
-func (r *ChoreRepository) UndoChoreAction(c context.Context, choreID int, historyID int, previousAssignedTo *int, previousDueDate *time.Time) error {
+func (r *ChoreRepository) UndoChoreAction(c context.Context, choreID int, historyID int, circleID int, previousAssignedTo *int, previousDueDate *time.Time) error {
+	nextVersion, err := r.nextSyncVersion(c, circleID)
+	if err != nil {
+		return err
+	}
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
 		// Get the history entry to undo
 		var historyToUndo chModel.ChoreHistory
@@ -843,11 +972,12 @@ func (r *ChoreRepository) UndoChoreAction(c context.Context, choreID int, histor
 
 		// Prepare chore updates
 		choreUpdates := map[string]interface{}{
-			"status": chModel.ChoreStatusNoStatus,
+			"status":       chModel.ChoreStatusNoStatus,
+			"sync_version": nextVersion,
 		}
 
 		// Build list of fields to explicitly update (including nullable fields)
-		selectFields := []string{"status"}
+		selectFields := []string{"status", "sync_version"}
 
 		// Restore previous assignee
 		if previousAssignedTo != nil {
@@ -857,14 +987,15 @@ func (r *ChoreRepository) UndoChoreAction(c context.Context, choreID int, histor
 		}
 		selectFields = append(selectFields, "assigned_to")
 
-		// Restore previous due date
+		// Restore previous due date; always reactivate since the chore was
+		// active before completion (e.g. "once" chores have no due date but
+		// must be unarchived on undo).
 		if previousDueDate != nil {
 			choreUpdates["next_due_date"] = *previousDueDate
-			choreUpdates["is_active"] = true
 		} else {
 			choreUpdates["next_due_date"] = nil
-			choreUpdates["is_active"] = false
 		}
+		choreUpdates["is_active"] = true
 		selectFields = append(selectFields, "next_due_date", "is_active")
 
 		// Update the chore with explicit field selection to handle nil values

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -9,6 +9,8 @@ import (
 	config "donetick.com/core/config"
 	chModel "donetick.com/core/internal/chore/model"
 	cModel "donetick.com/core/internal/circle/model"
+	storageModel "donetick.com/core/internal/storage/model"
+	stModel "donetick.com/core/internal/subtask/model"
 	syncModel "donetick.com/core/internal/sync/model"
 	"donetick.com/core/logging"
 	"gorm.io/gorm"
@@ -23,9 +25,9 @@ func NewChoreRepository(db *gorm.DB, cfg *config.Config) *ChoreRepository {
 	return &ChoreRepository{db: db, dbType: cfg.Database.Type}
 }
 
-func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (int64, error) {
+func (r *ChoreRepository) nextSyncVersionWithDB(ctx context.Context, db *gorm.DB, circleID int) (int64, error) {
 	var version int64
-	err := r.db.WithContext(ctx).Raw(`
+	err := db.WithContext(ctx).Raw(`
 		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
 		VALUES (?, ?, 1)
 		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + 1
@@ -35,16 +37,14 @@ func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (in
 	return version, err
 }
 
+func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (int64, error) {
+	return r.nextSyncVersionWithDB(ctx, r.db, circleID)
+}
+
 func (r *ChoreRepository) insertTombstone(ctx context.Context, tx *gorm.DB, circleID int, entityID int) error {
 	// Use tx (not r.db) so the version increment and tombstone insert are atomic.
-	var version int64
-	if err := tx.WithContext(ctx).Raw(`
-		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
-		VALUES (?, ?, 1)
-		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + 1
-		RETURNING max_version`,
-		circleID, syncModel.EntityTypeChore,
-	).Scan(&version).Error; err != nil {
+	version, err := r.nextSyncVersionWithDB(ctx, tx, circleID)
+	if err != nil {
 		return err
 	}
 	return tx.WithContext(ctx).Create(&syncModel.Tombstone{
@@ -68,7 +68,7 @@ func (r *ChoreRepository) UpdateChorePriority(c context.Context, userID int, cho
 	if err != nil {
 		return err
 	}
-	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 		"priority":     priority,
 		"sync_version": nextVersion,
 	})
@@ -107,12 +107,19 @@ func (r *ChoreRepository) nextSyncVersionRange(ctx context.Context, circleID int
 
 func (r *ChoreRepository) UpdateChores(c context.Context, chores []*chModel.Chore) error {
 	if len(chores) > 0 {
-		startVersion, err := r.nextSyncVersionRange(c, chores[0].CircleID, len(chores))
-		if err != nil {
-			return err
-		}
+		circleIndexes := make(map[int][]int)
 		for i, ch := range chores {
-			ch.SyncVersion = startVersion + int64(i)
+			circleIndexes[ch.CircleID] = append(circleIndexes[ch.CircleID], i)
+		}
+
+		for circleID, indexes := range circleIndexes {
+			startVersion, err := r.nextSyncVersionRange(c, circleID, len(indexes))
+			if err != nil {
+				return err
+			}
+			for offset, idx := range indexes {
+				chores[idx].SyncVersion = startVersion + int64(offset)
+			}
 		}
 	}
 	return r.db.WithContext(c).Save(&chores).Error
@@ -171,9 +178,35 @@ func (r *ChoreRepository) DeleteChore(c context.Context, id int) error {
 		return err
 	}
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+		// Delete all chore assignees
+		if err := tx.Where("chore_id = ?", id).Delete(&chModel.ChoreAssignees{}).Error; err != nil {
+			return err
+		}
+		// Delete all time sessions
+		if err := tx.Where("chore_id = ?", id).Delete(&chModel.TimeSession{}).Error; err != nil {
+			return err
+		}
+		// Delete all chore histories
+		if err := tx.Where("chore_id = ?", id).Delete(&chModel.ChoreHistory{}).Error; err != nil {
+			return err
+		}
+		// Delete all subtasks
+		if err := tx.Where("chore_id = ?", id).Delete(&stModel.SubTask{}).Error; err != nil {
+			return err
+		}
+		// Delete all chore labels
+		if err := tx.Where("chore_id = ?", id).Delete(&chModel.ChoreLabels{}).Error; err != nil {
+			return err
+		}
+		// Delete all storage files associated with the chore
+		if err := tx.Where("entity_type = ? AND entity_id = ?", storageModel.EntityTypeChoreDescription, id).Delete(&storageModel.StorageFile{}).Error; err != nil {
+			return err
+		}
+		// Delete the chore itself
 		if err := tx.Delete(&chModel.Chore{}, id).Error; err != nil {
 			return err
 		}
+		// Record tombstone so clients can remove it during sync
 		return r.insertTombstone(c, tx, chore.CircleID, id)
 	})
 }
@@ -549,14 +582,50 @@ func (r *ChoreRepository) GetChoreHistoryByID(c context.Context, choreID int, hi
 }
 
 func (r *ChoreRepository) CreateChoreHistory(c context.Context, history *chModel.ChoreHistory) error {
+	// Get the circle_id from the associated chore
+	var chore chModel.Chore
+	if err := r.db.WithContext(c).Select("circle_id").First(&chore, history.ChoreID).Error; err != nil {
+		return fmt.Errorf("failed to get chore for history creation: %w", err)
+	}
+
+	// Allocate sync version for this history
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return fmt.Errorf("failed to allocate sync version: %w", err)
+	}
+
+	history.SyncVersion = nextVersion
 	return r.db.WithContext(c).Create(history).Error
 }
 
 func (r *ChoreRepository) UpdateChoreHistory(c context.Context, history *chModel.ChoreHistory) error {
+	// Get the circle_id from the associated chore
+	var chore chModel.Chore
+	if err := r.db.WithContext(c).Select("circle_id").First(&chore, history.ChoreID).Error; err != nil {
+		return fmt.Errorf("failed to get chore for history update: %w", err)
+	}
+
+	// Every history update must get a fresh sync version so it is visible to sync clients.
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return fmt.Errorf("failed to allocate sync version: %w", err)
+	}
+	history.SyncVersion = nextVersion
+
 	return r.db.WithContext(c).Save(history).Error
 }
 
 func (r *ChoreRepository) UpdateLatestChoreHistory(c context.Context, choreID int, updates map[string]interface{}) error {
+	var chore chModel.Chore
+	if err := r.db.WithContext(c).Select("circle_id").First(&chore, choreID).Error; err != nil {
+		return fmt.Errorf("failed to get chore for latest history update: %w", err)
+	}
+	nextVersion, err := r.nextSyncVersion(c, chore.CircleID)
+	if err != nil {
+		return fmt.Errorf("failed to allocate sync version: %w", err)
+	}
+	updates["sync_version"] = nextVersion
+
 	// get the latest chore history for the given chore ID
 	var latestHistory chModel.ChoreHistory
 	if err := r.db.WithContext(c).Where("chore_id = ?", choreID).Order("created_at desc").First(&latestHistory).Error; err != nil {
@@ -573,12 +642,14 @@ func (r *ChoreRepository) UpdateLatestChoreHistory(c context.Context, choreID in
 }
 
 func (r *ChoreRepository) DeleteChoreHistory(c context.Context, historyID int, circleID int) error {
-	nextVersion, err := r.nextSyncVersion(c, circleID)
-	if err != nil {
-		return err
-	}
-	// create transaction and delete all the chore timer assiociated with the chore history then delete the chore history
+	// create transaction and delete all the chore timer associated with the chore history then delete the chore history
 	return r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+		// Allocate next sync version within the transaction for atomicity
+		nextVersion, err := r.nextSyncVersionWithDB(c, tx, circleID)
+		if err != nil {
+			return err
+		}
+
 		if err := tx.WithContext(c).Where("chore_history_id = ?", historyID).Delete(&chModel.TimeSession{}).Error; err != nil {
 			return fmt.Errorf("failed to delete chore time sessions: %w", err)
 		}

--- a/internal/circle/handler.go
+++ b/internal/circle/handler.go
@@ -234,7 +234,7 @@ func (h *Handler) LeaveCircle(c *gin.Context) {
 }
 
 func handleUserLeavingCircle(h *Handler, c *gin.Context, leavingUser *uModel.User, orginalCircleID int) error {
-	userAssignedCircleChores, err := h.choreRepo.GetChores(c, leavingUser.CircleID, leavingUser.ID, true)
+	userAssignedCircleChores, err := h.choreRepo.GetChores(c, leavingUser.CircleID, leavingUser.ID, true, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -19,9 +19,9 @@ import (
 	projModel "donetick.com/core/internal/project/model"
 	storageModel "donetick.com/core/internal/storage/model"
 	stModel "donetick.com/core/internal/subtask/model"
+	syncModel "donetick.com/core/internal/sync/model"
 	tModel "donetick.com/core/internal/thing/model"
 	uModel "donetick.com/core/internal/user/model" // Pure go SQLite driver, checkout https://github.com/glebarez/sqlite for details
-	syncModel "donetick.com/core/internal/sync/model"
 	"donetick.com/core/migrations"
 )
 

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -21,6 +21,7 @@ import (
 	stModel "donetick.com/core/internal/subtask/model"
 	tModel "donetick.com/core/internal/thing/model"
 	uModel "donetick.com/core/internal/user/model" // Pure go SQLite driver, checkout https://github.com/glebarez/sqlite for details
+	syncModel "donetick.com/core/internal/sync/model"
 	"donetick.com/core/migrations"
 )
 
@@ -60,6 +61,8 @@ func Migration(db *gorm.DB) error {
 		storageModel.StorageUsage{},
 		chModel.TimeSession{},
 		uModel.UserDeviceToken{},
+		syncModel.SyncCursor{},
+		syncModel.Tombstone{},
 	); err != nil {
 		return err
 	}

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -74,10 +74,6 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 	if hasMoreChoreTombstones {
 		choreTombstones = choreTombstones[:defaultSyncLimit]
 	}
-	deletedChoreIDs := make([]int, 0, len(choreTombstones))
-	for _, t := range choreTombstones {
-		deletedChoreIDs = append(deletedChoreIDs, t.EntityID)
-	}
 
 	// Use sync-aware GetChoresHistoryByCircle with privacy filtering.
 	histories, err := h.choreRepo.GetChoresHistoryByCircle(c, circleID, userID, syncOpts)
@@ -99,16 +95,14 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 	if hasMoreHistoryTombstones {
 		historyTombstones = historyTombstones[:defaultSyncLimit]
 	}
-	deletedHistoryIDs := make([]int, 0, len(historyTombstones))
-	for _, t := range historyTombstones {
-		deletedHistoryIDs = append(deletedHistoryIDs, t.EntityID)
-	}
 
 	hasMore := hasMoreChores || hasMoreHistories || hasMoreChoreTombstones || hasMoreHistoryTombstones
 
 	// Compute the next cursor:
 	// - If any stream was truncated (hasMore* == true), the cursor is the minimum
 	//   last sync_version among truncated streams — we must not skip their unsent items.
+	//   Then cap every returned stream to <= cursor so the cursor means
+	//   "everything <= cursor has been delivered".
 	// - If all streams are fully drained, the cursor advances to the maximum last
 	//   sync_version across all streams, so the next request truly starts fresh.
 	cursor := since
@@ -145,6 +139,39 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 		}
 		if !first {
 			cursor = minTruncated
+
+			// Keep page boundary consistent across all streams.
+			cappedChores := chores[:0]
+			for _, item := range chores {
+				if item.SyncVersion <= cursor {
+					cappedChores = append(cappedChores, item)
+				}
+			}
+			chores = cappedChores
+
+			cappedHistories := histories[:0]
+			for _, item := range histories {
+				if item.SyncVersion <= cursor {
+					cappedHistories = append(cappedHistories, item)
+				}
+			}
+			histories = cappedHistories
+
+			cappedChoreTombstones := choreTombstones[:0]
+			for _, item := range choreTombstones {
+				if item.SyncVersion <= cursor {
+					cappedChoreTombstones = append(cappedChoreTombstones, item)
+				}
+			}
+			choreTombstones = cappedChoreTombstones
+
+			cappedHistoryTombstones := historyTombstones[:0]
+			for _, item := range historyTombstones {
+				if item.SyncVersion <= cursor {
+					cappedHistoryTombstones = append(cappedHistoryTombstones, item)
+				}
+			}
+			historyTombstones = cappedHistoryTombstones
 		}
 	} else {
 		// All streams fully drained — advance to the max version seen.
@@ -171,6 +198,16 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 		if hasAny {
 			cursor = maxAll
 		}
+	}
+
+	deletedChoreIDs := make([]int, 0, len(choreTombstones))
+	for _, t := range choreTombstones {
+		deletedChoreIDs = append(deletedChoreIDs, t.EntityID)
+	}
+
+	deletedHistoryIDs := make([]int, 0, len(historyTombstones))
+	for _, t := range historyTombstones {
+		deletedHistoryIDs = append(deletedHistoryIDs, t.EntityID)
 	}
 
 	c.JSON(200, gin.H{

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -32,39 +32,104 @@ func (h *SyncHandler) getChanges(c *gin.Context) {
 		return
 	}
 
-	// Fetch one extra to determine hasMore
+	// Fetch one extra from each stream to determine if there are more changes.
 	chores, err := h.choreRepo.GetChoreChangesSince(c, circleID, since, defaultSyncLimit+1)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch changes"})
 		return
 	}
 
-	hasMore := len(chores) > defaultSyncLimit
-	if hasMore {
+	hasMoreChores := len(chores) > defaultSyncLimit
+	if hasMoreChores {
 		chores = chores[:defaultSyncLimit]
 	}
 
-	var cursor int64
-	if len(chores) > 0 {
-		cursor = chores[len(chores)-1].SyncVersion
-	} else {
-		cursor = since
-	}
-
-	tombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChore, since)
+	choreTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChore, since, defaultSyncLimit+1)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch deletions"})
 		return
 	}
+	hasMoreChoreTombstones := len(choreTombstones) > defaultSyncLimit
+	if hasMoreChoreTombstones {
+		choreTombstones = choreTombstones[:defaultSyncLimit]
+	}
+	deletedChoreIDs := make([]int, 0, len(choreTombstones))
+	for _, t := range choreTombstones {
+		deletedChoreIDs = append(deletedChoreIDs, t.EntityID)
+	}
 
-	deletedIDs := make([]int, 0, len(tombstones))
-	for _, t := range tombstones {
-		deletedIDs = append(deletedIDs, t.EntityID)
+	histories, err := h.choreRepo.GetChoreHistoryChangesSince(c, circleID, since, defaultSyncLimit+1)
+	if err != nil {
+		c.JSON(500, gin.H{"error": "Failed to fetch history changes"})
+		return
+	}
+	hasMoreHistories := len(histories) > defaultSyncLimit
+	if hasMoreHistories {
+		histories = histories[:defaultSyncLimit]
+	}
+
+	historyTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChoreHistory, since, defaultSyncLimit+1)
+	if err != nil {
+		c.JSON(500, gin.H{"error": "Failed to fetch history deletions"})
+		return
+	}
+	hasMoreHistoryTombstones := len(historyTombstones) > defaultSyncLimit
+	if hasMoreHistoryTombstones {
+		historyTombstones = historyTombstones[:defaultSyncLimit]
+	}
+	deletedHistoryIDs := make([]int, 0, len(historyTombstones))
+	for _, t := range historyTombstones {
+		deletedHistoryIDs = append(deletedHistoryIDs, t.EntityID)
+	}
+
+	hasMore := hasMoreChores || hasMoreHistories || hasMoreChoreTombstones || hasMoreHistoryTombstones
+
+	cursor := since
+	hasAny := false
+	minLast := int64(0)
+
+	if len(chores) > 0 {
+		last := chores[len(chores)-1].SyncVersion
+		if !hasAny || last < minLast {
+			minLast = last
+		}
+		hasAny = true
+	}
+	if len(histories) > 0 {
+		last := histories[len(histories)-1].SyncVersion
+		if !hasAny || last < minLast {
+			minLast = last
+		}
+		hasAny = true
+	}
+	if len(choreTombstones) > 0 {
+		last := choreTombstones[len(choreTombstones)-1].SyncVersion
+		if !hasAny || last < minLast {
+			minLast = last
+		}
+		hasAny = true
+	}
+	if len(historyTombstones) > 0 {
+		last := historyTombstones[len(historyTombstones)-1].SyncVersion
+		if !hasAny || last < minLast {
+			minLast = last
+		}
+		hasAny = true
+	}
+
+	if hasAny {
+		cursor = minLast
 	}
 
 	c.JSON(200, gin.H{
-		"changes":  gin.H{"chores": chores},
-		"deletions": gin.H{"chores": deletedIDs},
+		"changes": gin.H{
+			"chores":         chores,
+			"choreHistories": histories,
+		},
+		"deletions": gin.H{
+			"chores":         deletedChoreIDs,
+			"choreHistories": deletedHistoryIDs,
+		},
 		"cursor":  cursor,
 		"hasMore": hasMore,
 	})

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -21,7 +21,22 @@ func NewHandler(cr *chRepo.ChoreRepository) *SyncHandler {
 	}
 }
 
-func (h *SyncHandler) getChanges(c *gin.Context) {
+// GetChanges godoc
+//
+//	@Summary		Get sync changes
+//	@Description	Returns chores and chore histories that have changed since the given sync version cursor, along with deleted entity IDs. Paginated — call repeatedly while hasMore is true using the returned cursor.
+//	@Tags			sync
+//	@Accept			json
+//	@Produce		json
+//	@Security		JWTKeyAuth
+//	@Security		APIKeyAuth
+//	@Param			since	query		int64		false	"Sync version cursor (0 for initial full sync)"	default(0)
+//	@Success		200		{object}	map[string]interface{}	"changes, deletions, cursor, hasMore"
+//	@Failure		400		{object}	map[string]string		"error: Invalid 'since' parameter"
+//	@Failure		401		{object}	map[string]string		"error: Authentication failed"
+//	@Failure		500		{object}	map[string]string		"error: Failed to fetch changes"
+//	@Router			/sync/changes [get]
+func (h *SyncHandler) GetChanges(c *gin.Context) {
 	currentUser := auth.MustCurrentUser(c)
 	circleID := currentUser.CircleID
 	userID := currentUser.ID
@@ -176,6 +191,6 @@ func Routes(router *gin.Engine, h *SyncHandler, auth *auth.MultiAuthMiddleware) 
 	syncRoutes := router.Group("api/v1/sync")
 	syncRoutes.Use(auth.MiddlewareFunc())
 	{
-		syncRoutes.GET("/changes", h.getChanges)
+		syncRoutes.GET("/changes", h.GetChanges)
 	}
 }

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -24,6 +24,7 @@ func NewHandler(cr *chRepo.ChoreRepository) *SyncHandler {
 func (h *SyncHandler) getChanges(c *gin.Context) {
 	currentUser := auth.MustCurrentUser(c)
 	circleID := currentUser.CircleID
+	userID := currentUser.ID
 
 	sinceStr := c.DefaultQuery("since", "0")
 	since, err := strconv.ParseInt(sinceStr, 10, 64)
@@ -33,7 +34,12 @@ func (h *SyncHandler) getChanges(c *gin.Context) {
 	}
 
 	// Fetch one extra from each stream to determine if there are more changes.
-	chores, err := h.choreRepo.GetChoreChangesSince(c, circleID, since, defaultSyncLimit+1)
+	// Use sync-aware GetChores with privacy filtering.
+	syncOpts := &chRepo.SyncOptions{
+		SyncVersion: &since,
+		Limit:       defaultSyncLimit,
+	}
+	chores, err := h.choreRepo.GetChores(c, circleID, userID, true, syncOpts)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch changes"})
 		return
@@ -58,7 +64,8 @@ func (h *SyncHandler) getChanges(c *gin.Context) {
 		deletedChoreIDs = append(deletedChoreIDs, t.EntityID)
 	}
 
-	histories, err := h.choreRepo.GetChoreHistoryChangesSince(c, circleID, since, defaultSyncLimit+1)
+	// Use sync-aware GetChoresHistoryByCircle with privacy filtering.
+	histories, err := h.choreRepo.GetChoresHistoryByCircle(c, circleID, userID, syncOpts)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch history changes"})
 		return

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -1,0 +1,79 @@
+package sync
+
+import (
+	"strconv"
+
+	auth "donetick.com/core/internal/auth"
+	chRepo "donetick.com/core/internal/chore/repo"
+	syncModel "donetick.com/core/internal/sync/model"
+	"github.com/gin-gonic/gin"
+)
+
+const defaultSyncLimit = 200
+
+type SyncHandler struct {
+	choreRepo *chRepo.ChoreRepository
+}
+
+func NewHandler(cr *chRepo.ChoreRepository) *SyncHandler {
+	return &SyncHandler{
+		choreRepo: cr,
+	}
+}
+
+func (h *SyncHandler) getChanges(c *gin.Context) {
+	currentUser := auth.MustCurrentUser(c)
+	circleID := currentUser.CircleID
+
+	sinceStr := c.DefaultQuery("since", "0")
+	since, err := strconv.ParseInt(sinceStr, 10, 64)
+	if err != nil {
+		c.JSON(400, gin.H{"error": "Invalid 'since' parameter"})
+		return
+	}
+
+	// Fetch one extra to determine hasMore
+	chores, err := h.choreRepo.GetChoreChangesSince(c, circleID, since, defaultSyncLimit+1)
+	if err != nil {
+		c.JSON(500, gin.H{"error": "Failed to fetch changes"})
+		return
+	}
+
+	hasMore := len(chores) > defaultSyncLimit
+	if hasMore {
+		chores = chores[:defaultSyncLimit]
+	}
+
+	var cursor int64
+	if len(chores) > 0 {
+		cursor = chores[len(chores)-1].SyncVersion
+	} else {
+		cursor = since
+	}
+
+	tombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChore, since)
+	if err != nil {
+		c.JSON(500, gin.H{"error": "Failed to fetch deletions"})
+		return
+	}
+
+	deletedIDs := make([]int, 0, len(tombstones))
+	for _, t := range tombstones {
+		deletedIDs = append(deletedIDs, t.EntityID)
+	}
+
+	c.JSON(200, gin.H{
+		"changes":  gin.H{"chores": chores},
+		"deletions": gin.H{"chores": deletedIDs},
+		"cursor":  cursor,
+		"hasMore": hasMore,
+	})
+}
+
+func Routes(router *gin.Engine, h *SyncHandler, auth *auth.MultiAuthMiddleware) {
+	syncRoutes := router.Group("api/v1/sync")
+	syncRoutes.Use(auth.MiddlewareFunc())
+	{
+		syncRoutes.GET("/changes", h.getChanges)
+	}
+}

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -84,41 +84,71 @@ func (h *SyncHandler) getChanges(c *gin.Context) {
 
 	hasMore := hasMoreChores || hasMoreHistories || hasMoreChoreTombstones || hasMoreHistoryTombstones
 
+	// Compute the next cursor:
+	// - If any stream was truncated (hasMore* == true), the cursor is the minimum
+	//   last sync_version among truncated streams — we must not skip their unsent items.
+	// - If all streams are fully drained, the cursor advances to the maximum last
+	//   sync_version across all streams, so the next request truly starts fresh.
 	cursor := since
-	hasAny := false
-	minLast := int64(0)
-
-	if len(chores) > 0 {
-		last := chores[len(chores)-1].SyncVersion
-		if !hasAny || last < minLast {
-			minLast = last
+	if hasMore {
+		first := true
+		minTruncated := int64(0)
+		if hasMoreChores && len(chores) > 0 {
+			v := chores[len(chores)-1].SyncVersion
+			if first || v < minTruncated {
+				minTruncated = v
+				first = false
+			}
 		}
-		hasAny = true
-	}
-	if len(histories) > 0 {
-		last := histories[len(histories)-1].SyncVersion
-		if !hasAny || last < minLast {
-			minLast = last
+		if hasMoreHistories && len(histories) > 0 {
+			v := histories[len(histories)-1].SyncVersion
+			if first || v < minTruncated {
+				minTruncated = v
+				first = false
+			}
 		}
-		hasAny = true
-	}
-	if len(choreTombstones) > 0 {
-		last := choreTombstones[len(choreTombstones)-1].SyncVersion
-		if !hasAny || last < minLast {
-			minLast = last
+		if hasMoreChoreTombstones && len(choreTombstones) > 0 {
+			v := choreTombstones[len(choreTombstones)-1].SyncVersion
+			if first || v < minTruncated {
+				minTruncated = v
+				first = false
+			}
 		}
-		hasAny = true
-	}
-	if len(historyTombstones) > 0 {
-		last := historyTombstones[len(historyTombstones)-1].SyncVersion
-		if !hasAny || last < minLast {
-			minLast = last
+		if hasMoreHistoryTombstones && len(historyTombstones) > 0 {
+			v := historyTombstones[len(historyTombstones)-1].SyncVersion
+			if first || v < minTruncated {
+				minTruncated = v
+				first = false
+			}
 		}
-		hasAny = true
-	}
-
-	if hasAny {
-		cursor = minLast
+		if !first {
+			cursor = minTruncated
+		}
+	} else {
+		// All streams fully drained — advance to the max version seen.
+		hasAny := false
+		maxAll := int64(0)
+		updateMax := func(v int64) {
+			if v > 0 && (!hasAny || v > maxAll) {
+				maxAll = v
+				hasAny = true
+			}
+		}
+		if len(chores) > 0 {
+			updateMax(chores[len(chores)-1].SyncVersion)
+		}
+		if len(histories) > 0 {
+			updateMax(histories[len(histories)-1].SyncVersion)
+		}
+		if len(choreTombstones) > 0 {
+			updateMax(choreTombstones[len(choreTombstones)-1].SyncVersion)
+		}
+		if len(historyTombstones) > 0 {
+			updateMax(historyTombstones[len(historyTombstones)-1].SyncVersion)
+		}
+		if hasAny {
+			cursor = maxAll
+		}
 	}
 
 	c.JSON(200, gin.H{

--- a/internal/sync/model/model.go
+++ b/internal/sync/model/model.go
@@ -10,7 +10,8 @@ type SyncCursor struct {
 type EntityType int8
 
 const (
-	EntityTypeChore EntityType = 1
+	EntityTypeChore        EntityType = 1
+	EntityTypeChoreHistory EntityType = 2
 )
 
 type Tombstone struct {

--- a/internal/sync/model/model.go
+++ b/internal/sync/model/model.go
@@ -1,0 +1,22 @@
+package model
+
+type SyncCursor struct {
+	ID         int        `json:"id" gorm:"primaryKey;autoIncrement"`
+	CircleID   int        `json:"circleId" gorm:"column:circle_id;not null;uniqueIndex:idx_sync_cursors_circle_entity"`
+	EntityType EntityType `json:"entityType" gorm:"column:entity_type;not null;uniqueIndex:idx_sync_cursors_circle_entity"`
+	MaxVersion int64      `json:"maxVersion" gorm:"column:max_version;not null;default:0"`
+}
+
+type EntityType int8
+
+const (
+	EntityTypeChore EntityType = 1
+)
+
+type Tombstone struct {
+	ID          int        `json:"id" gorm:"primaryKey;autoIncrement"`
+	CircleID    int        `json:"circleId" gorm:"column:circle_id;not null;index:idx_tombstone_sync"`
+	EntityType  EntityType `json:"entityType" gorm:"column:entity_type;not null;index:idx_tombstone_sync"`
+	EntityID    int        `json:"entityId" gorm:"column:entity_id;not null;index:idx_tombstone_sync"`
+	SyncVersion int64      `json:"syncVersion" gorm:"column:sync_version;not null;index:idx_tombstone_sync"`
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	"donetick.com/core/internal/storage"
 	storageRepo "donetick.com/core/internal/storage/repo"
 	spRepo "donetick.com/core/internal/subtask/repo"
+	dsync "donetick.com/core/internal/sync"
 	"donetick.com/core/internal/thing"
 	tRepo "donetick.com/core/internal/thing/repo"
 	"donetick.com/core/internal/user"
@@ -158,6 +159,9 @@ func main() {
 		fx.Provide(payment.NewWebhook),
 		fx.Provide(chore.NewAPI),
 
+		// Sync:
+		fx.Provide(dsync.NewHandler),
+
 		// Frontend
 		fx.Provide(frontend.NewHandler),
 
@@ -203,6 +207,7 @@ func main() {
 			resource.Routes,
 			// backup.Routes,
 
+			dsync.Routes,
 			realtime.Routes, // (router, rts, authMiddleware, pollingHandler)
 
 			func(r *gin.Engine) {},

--- a/migrations/20260511_backfill_sync_versions_for_existing_data.go
+++ b/migrations/20260511_backfill_sync_versions_for_existing_data.go
@@ -96,53 +96,83 @@ func (m BackfillSyncVersionsForExistingData20260511) Up(ctx context.Context, db 
 
 			currentVersion := maxInt64(maxChoreVersion, maxHistoryVersion, maxTombstoneVersion, maxCursorVersion)
 
-			var choreIDs []idRow
+			// Batch update chores with sync_version = 0 using window functions
+			var choreCount int64
 			if err := tx.Raw(`
-				SELECT id
-				FROM chores
-				WHERE circle_id = ? AND sync_version = 0
-				ORDER BY created_at ASC, id ASC
-			`, circle.CircleID).Scan(&choreIDs).Error; err != nil {
+				SELECT COUNT(*) FROM chores WHERE circle_id = ? AND sync_version = 0
+			`, circle.CircleID).Scan(&choreCount).Error; err != nil {
 				return err
 			}
-			for _, chore := range choreIDs {
-				currentVersion++
-				if err := tx.Table("chores").Where("id = ?", chore.ID).Update("sync_version", currentVersion).Error; err != nil {
+
+			if choreCount > 0 {
+				if err := tx.Exec(`
+					WITH numbered_chores AS (
+						SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC, id ASC) AS rn
+						FROM chores
+						WHERE circle_id = ? AND sync_version = 0
+					)
+					UPDATE chores
+					SET sync_version = ? + nc.rn
+					FROM numbered_chores nc
+					WHERE chores.id = nc.id
+				`, circle.CircleID, currentVersion).Error; err != nil {
 					return err
 				}
+				currentVersion += choreCount
 			}
 
-			var historyIDs []idRow
+			// Batch update chore histories with sync_version = 0 using window functions
+			var historyCount int64
 			if err := tx.Raw(`
-				SELECT chore_histories.id
+				SELECT COUNT(chore_histories.id)
 				FROM chore_histories
 				JOIN chores ON chores.id = chore_histories.chore_id
 				WHERE chores.circle_id = ? AND chore_histories.sync_version = 0
-				ORDER BY chore_histories.created_at ASC, chore_histories.id ASC
-			`, circle.CircleID).Scan(&historyIDs).Error; err != nil {
+			`, circle.CircleID).Scan(&historyCount).Error; err != nil {
 				return err
-			}
-			for _, history := range historyIDs {
-				currentVersion++
-				if err := tx.Table("chore_histories").Where("id = ?", history.ID).Update("sync_version", currentVersion).Error; err != nil {
-					return err
-				}
 			}
 
-			var tombstoneIDs []idRow
-			if err := tx.Raw(`
-				SELECT id
-				FROM tombstones
-				WHERE circle_id = ? AND sync_version = 0
-				ORDER BY id ASC
-			`, circle.CircleID).Scan(&tombstoneIDs).Error; err != nil {
-				return err
-			}
-			for _, tombstone := range tombstoneIDs {
-				currentVersion++
-				if err := tx.Table("tombstones").Where("id = ?", tombstone.ID).Update("sync_version", currentVersion).Error; err != nil {
+			if historyCount > 0 {
+				if err := tx.Exec(`
+					WITH numbered_histories AS (
+						SELECT chore_histories.id, ROW_NUMBER() OVER (ORDER BY chore_histories.created_at ASC, chore_histories.id ASC) AS rn
+						FROM chore_histories
+						JOIN chores ON chores.id = chore_histories.chore_id
+						WHERE chores.circle_id = ? AND chore_histories.sync_version = 0
+					)
+					UPDATE chore_histories
+					SET sync_version = ? + nh.rn
+					FROM numbered_histories nh
+					WHERE chore_histories.id = nh.id
+				`, circle.CircleID, currentVersion).Error; err != nil {
 					return err
 				}
+				currentVersion += historyCount
+			}
+
+			// Batch update tombstones with sync_version = 0 using window functions
+			var tombstoneCount int64
+			if err := tx.Raw(`
+				SELECT COUNT(*) FROM tombstones WHERE circle_id = ? AND sync_version = 0
+			`, circle.CircleID).Scan(&tombstoneCount).Error; err != nil {
+				return err
+			}
+
+			if tombstoneCount > 0 {
+				if err := tx.Exec(`
+					WITH numbered_tombstones AS (
+						SELECT id, ROW_NUMBER() OVER (ORDER BY id ASC) AS rn
+						FROM tombstones
+						WHERE circle_id = ? AND sync_version = 0
+					)
+					UPDATE tombstones
+					SET sync_version = ? + nt.rn
+					FROM numbered_tombstones nt
+					WHERE tombstones.id = nt.id
+				`, circle.CircleID, currentVersion).Error; err != nil {
+					return err
+				}
+				currentVersion += tombstoneCount
 			}
 
 			if err := tx.Exec(`
@@ -158,12 +188,12 @@ func (m BackfillSyncVersionsForExistingData20260511) Up(ctx context.Context, db 
 				return err
 			}
 
-			totalChoresUpdated += len(choreIDs)
-			totalHistoriesUpdated += len(historyIDs)
-			totalTombstonesUpdated += len(tombstoneIDs)
+			totalChoresUpdated += int(choreCount)
+			totalHistoriesUpdated += int(historyCount)
+			totalTombstonesUpdated += int(tombstoneCount)
 
-			if len(choreIDs)+len(historyIDs)+len(tombstoneIDs) > 0 {
-				log.Infof("Sync backfill circle=%d chores=%d histories=%d tombstones=%d maxVersion=%d", circle.CircleID, len(choreIDs), len(historyIDs), len(tombstoneIDs), currentVersion)
+			if choreCount+historyCount+tombstoneCount > 0 {
+				log.Infof("Sync backfill circle=%d chores=%d histories=%d tombstones=%d maxVersion=%d", circle.CircleID, choreCount, historyCount, tombstoneCount, currentVersion)
 			}
 
 			return nil

--- a/migrations/20260511_backfill_sync_versions_for_existing_data.go
+++ b/migrations/20260511_backfill_sync_versions_for_existing_data.go
@@ -1,0 +1,183 @@
+package migrations
+
+import (
+	"context"
+
+	"donetick.com/core/internal/sync/model"
+	"donetick.com/core/logging"
+	"gorm.io/gorm"
+)
+
+type BackfillSyncVersionsForExistingData20260511 struct{}
+
+func (m BackfillSyncVersionsForExistingData20260511) ID() string {
+	return "20260511_backfill_sync_versions_for_existing_data"
+}
+
+func (m BackfillSyncVersionsForExistingData20260511) Description() string {
+	return `Backfill sync_version for legacy chores, chore histories, and tombstones with zero values; align sync cursor per circle.`
+}
+
+func (m BackfillSyncVersionsForExistingData20260511) Down(ctx context.Context, db *gorm.DB) error {
+	// No-op: irreversible data migration
+	return nil
+}
+
+func maxInt64(values ...int64) int64 {
+	maxValue := int64(0)
+	for _, value := range values {
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+	return maxValue
+}
+
+func (m BackfillSyncVersionsForExistingData20260511) Up(ctx context.Context, db *gorm.DB) error {
+	log := logging.FromContext(ctx)
+
+	type circleRow struct {
+		CircleID int `gorm:"column:circle_id"`
+	}
+	type idRow struct {
+		ID int `gorm:"column:id"`
+	}
+
+	var circles []circleRow
+	if err := db.WithContext(ctx).Raw(`
+		SELECT circle_id FROM chores
+		UNION
+		SELECT circle_id FROM tombstones
+		UNION
+		SELECT circle_id FROM sync_cursors
+	`).Scan(&circles).Error; err != nil {
+		log.Errorf("Failed to load circles for sync backfill: %v", err)
+		return err
+	}
+
+	totalChoresUpdated := 0
+	totalHistoriesUpdated := 0
+	totalTombstonesUpdated := 0
+
+	for _, circle := range circles {
+		if circle.CircleID == 0 {
+			continue
+		}
+
+		err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var maxChoreVersion int64
+			if err := tx.Raw(`SELECT COALESCE(MAX(sync_version), 0) FROM chores WHERE circle_id = ?`, circle.CircleID).Scan(&maxChoreVersion).Error; err != nil {
+				return err
+			}
+
+			var maxHistoryVersion int64
+			if err := tx.Raw(`
+				SELECT COALESCE(MAX(chore_histories.sync_version), 0)
+				FROM chore_histories
+				JOIN chores ON chores.id = chore_histories.chore_id
+				WHERE chores.circle_id = ?
+			`, circle.CircleID).Scan(&maxHistoryVersion).Error; err != nil {
+				return err
+			}
+
+			var maxTombstoneVersion int64
+			if err := tx.Raw(`SELECT COALESCE(MAX(sync_version), 0) FROM tombstones WHERE circle_id = ?`, circle.CircleID).Scan(&maxTombstoneVersion).Error; err != nil {
+				return err
+			}
+
+			var maxCursorVersion int64
+			if err := tx.Raw(`
+				SELECT COALESCE(MAX(max_version), 0)
+				FROM sync_cursors
+				WHERE circle_id = ?
+			`, circle.CircleID).Scan(&maxCursorVersion).Error; err != nil {
+				return err
+			}
+
+			currentVersion := maxInt64(maxChoreVersion, maxHistoryVersion, maxTombstoneVersion, maxCursorVersion)
+
+			var choreIDs []idRow
+			if err := tx.Raw(`
+				SELECT id
+				FROM chores
+				WHERE circle_id = ? AND sync_version = 0
+				ORDER BY created_at ASC, id ASC
+			`, circle.CircleID).Scan(&choreIDs).Error; err != nil {
+				return err
+			}
+			for _, chore := range choreIDs {
+				currentVersion++
+				if err := tx.Table("chores").Where("id = ?", chore.ID).Update("sync_version", currentVersion).Error; err != nil {
+					return err
+				}
+			}
+
+			var historyIDs []idRow
+			if err := tx.Raw(`
+				SELECT chore_histories.id
+				FROM chore_histories
+				JOIN chores ON chores.id = chore_histories.chore_id
+				WHERE chores.circle_id = ? AND chore_histories.sync_version = 0
+				ORDER BY chore_histories.created_at ASC, chore_histories.id ASC
+			`, circle.CircleID).Scan(&historyIDs).Error; err != nil {
+				return err
+			}
+			for _, history := range historyIDs {
+				currentVersion++
+				if err := tx.Table("chore_histories").Where("id = ?", history.ID).Update("sync_version", currentVersion).Error; err != nil {
+					return err
+				}
+			}
+
+			var tombstoneIDs []idRow
+			if err := tx.Raw(`
+				SELECT id
+				FROM tombstones
+				WHERE circle_id = ? AND sync_version = 0
+				ORDER BY id ASC
+			`, circle.CircleID).Scan(&tombstoneIDs).Error; err != nil {
+				return err
+			}
+			for _, tombstone := range tombstoneIDs {
+				currentVersion++
+				if err := tx.Table("tombstones").Where("id = ?", tombstone.ID).Update("sync_version", currentVersion).Error; err != nil {
+					return err
+				}
+			}
+
+			if err := tx.Exec(`
+				INSERT INTO sync_cursors (circle_id, entity_type, max_version)
+				VALUES (?, ?, ?)
+				ON CONFLICT (circle_id, entity_type)
+				DO UPDATE SET max_version =
+					CASE
+						WHEN sync_cursors.max_version > excluded.max_version THEN sync_cursors.max_version
+						ELSE excluded.max_version
+					END
+			`, circle.CircleID, model.EntityTypeChore, currentVersion).Error; err != nil {
+				return err
+			}
+
+			totalChoresUpdated += len(choreIDs)
+			totalHistoriesUpdated += len(historyIDs)
+			totalTombstonesUpdated += len(tombstoneIDs)
+
+			if len(choreIDs)+len(historyIDs)+len(tombstoneIDs) > 0 {
+				log.Infof("Sync backfill circle=%d chores=%d histories=%d tombstones=%d maxVersion=%d", circle.CircleID, len(choreIDs), len(historyIDs), len(tombstoneIDs), currentVersion)
+			}
+
+			return nil
+		})
+		if err != nil {
+			log.Errorf("Failed sync backfill for circle %d: %v", circle.CircleID, err)
+			return err
+		}
+	}
+
+	log.Infof("Sync backfill completed: chores=%d histories=%d tombstones=%d", totalChoresUpdated, totalHistoriesUpdated, totalTombstonesUpdated)
+	return nil
+}
+
+func init() {
+	Register(BackfillSyncVersionsForExistingData20260511{})
+}


### PR DESCRIPTION
Add synchronization support for chore-related operations, primarily by adding and updating a `SyncVersion` field on chore and chore history records. The changes ensure that any modification, deletion, or status update to a chore is tracked with an incrementing sync version, enabling more robust data synchronization across clients. Several repository methods and handler functions are updated to support and propagate the `SyncVersion`, and tombstone records are created for hard deletes to facilitate sync.
