### PR TITLE
Graceful Validation with Warnings. to make sure we have a non-breaking

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -244,7 +244,7 @@ type ChoreReq struct {
 	AssignedTo           *int                          `json:"assignedTo" binding:"omitempty,gt=0"`
 	Assignees            []chModel.ChoreAssignees      `json:"assignees" binding:"dive"`
 	AssignStrategy       chModel.AssignmentStrategy    `json:"assignStrategy" binding:"required,oneof=no_assignee least_assigned least_completed random keep_last_assigned random_except_last_assigned round_robin"`
-	IsActive             bool                          `json:"isActive"`
+	IsActive             *bool                         `json:"isActive" binding:"omitempty"`
 	Notification         bool                          `json:"notification"`
 	NotificationMetadata *chModel.NotificationMetadata `json:"notificationMetadata"`
 	LabelsV2             *[]lModel.LabelReq            `json:"labelsV2" binding:"omitempty,dive,unique=LabelID"`
@@ -255,7 +255,7 @@ type ChoreReq struct {
 	Description          *string                       `json:"description" binding:"omitempty"`
 	SubTasks             *[]stModel.SubTask            `json:"subTasks" binding:"omitempty,dive"`
 	RequireApproval      bool                          `json:"requireApproval" binding:"omitempty"`
-	IsPrivate            *bool                         `json:"isPrivate" binding:"required"`
+	IsPrivate            *bool                         `json:"isPrivate" binding:"omitempty"`
 	ProjectID            *int                          `json:"projectId" binding:"omitempty,gt=0"`
 	ThingTrigger         *tModel.ThingTrigger          `json:"thingTrigger"`
 }
@@ -331,7 +331,7 @@ func (h *Handler) CreateChore(c *gin.Context) {
 		dueDate = &utcDate
 	}
 
-	setCreateChoreDefaults(&choreReq)
+	warnings := setCreateChoreDefaults(&choreReq)
 
 	createdChore := &chModel.Chore{
 
@@ -344,7 +344,7 @@ func (h *Handler) CreateChore(c *gin.Context) {
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
 		UpdatedBy:              currentUser.ID,
-		IsActive:               choreReq.IsActive,
+		IsActive:               *choreReq.IsActive,
 		Notification:           choreReq.Notification,
 		NotificationMetadataV2: choreReq.NotificationMetadata,
 		CreatedBy:              currentUser.ID,
@@ -434,21 +434,42 @@ func (h *Handler) CreateChore(c *gin.Context) {
 	if shouldReturn {
 		return
 	}
-	c.JSON(200, gin.H{
-		"res": id,
-	})
+	response := gin.H{"res": id}
+	if len(warnings) > 0 {
+		response["warnings"] = warnings
+	}
+
+	c.JSON(200, response)
 }
 
-func setCreateChoreDefaults(choreReq *ChoreReq) {
+func setCreateChoreDefaults(choreReq *ChoreReq) []string {
+	warnings := []string{}
+
 	if choreReq.Frequency == nil {
 		val := 1
 		choreReq.Frequency = &val
+		warnings = append(warnings, "frequency not provided, defaulting to 1")
 	}
 
 	if choreReq.Priority == nil {
 		val := 0
 		choreReq.Priority = &val
+		warnings = append(warnings, "priority not provided, defaulting to 0")
 	}
+
+	if choreReq.IsActive == nil {
+		val := true
+		choreReq.IsActive = &val
+		warnings = append(warnings, "isActive not provided, defaulting to true")
+	}
+
+	if choreReq.IsPrivate == nil {
+		val := false
+		choreReq.IsPrivate = &val
+		warnings = append(warnings, "isPrivate not provided, defaulting to false")
+	}
+
+	return warnings
 }
 
 // EditChore godoc
@@ -648,7 +669,7 @@ func (h *Handler) EditChore(c *gin.Context) {
 		AssignStrategy:         choreReq.AssignStrategy,
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
-		IsActive:               choreReq.IsActive,
+		IsActive:               *choreReq.IsActive,
 		Notification:           choreReq.Notification,
 		NotificationMetadataV2: choreReq.NotificationMetadata,
 		CircleID:               oldChore.CircleID,
@@ -789,6 +810,14 @@ func setEditChoreDefaults(choreReq *ChoreReq, oldChore *chModel.Chore) {
 
 	if choreReq.Priority == nil {
 		choreReq.Priority = &oldChore.Priority
+	}
+
+	if choreReq.IsActive == nil {
+		choreReq.IsActive = &oldChore.IsActive
+	}
+
+	if choreReq.IsPrivate == nil {
+		choreReq.IsPrivate = &oldChore.IsPrivate
 	}
 }
 

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -332,6 +332,10 @@ func (h *Handler) CreateChore(c *gin.Context) {
 	}
 
 	warnings := setCreateChoreDefaults(&choreReq)
+	if !choreReq.Notification && choreReq.NotificationMetadata != nil {
+		warnings = append(warnings, "notificationMetadata provided while notification is false; ignoring metadata")
+		choreReq.NotificationMetadata = nil
+	}
 
 	createdChore := &chModel.Chore{
 

--- a/internal/chore/validator.go
+++ b/internal/chore/validator.go
@@ -105,7 +105,7 @@ func validateNotifications(sl validator.StructLevel, req ChoreReq) {
 			sl.ReportError(req.NotificationMetadata, "NotificationMetadata", "notificationMetadata", "required_when_notifications_enabled", "")
 		}
 	} else if hasNotificationMetadata {
-		// If notifications are disabled (or nil), ensure the client isn't sending unused metadata
+		// TODO(v0.1.78+): Re-enable strict validation once all clients stop sending notificationMetadata when notification is false.
 		// sl.ReportError(req.NotificationMetadata, "NotificationMetadata", "notificationMetadata", "forbidden_when_notifications_disabled", "")
 	}
 }

--- a/internal/chore/validator.go
+++ b/internal/chore/validator.go
@@ -11,9 +11,15 @@ import (
 func ChoreReqStructLevelValidation(sl validator.StructLevel) {
 	req := sl.Current().Interface().(ChoreReq)
 
-	validateFrequencyLogic(sl, req)     // 1. Validate Frequency Logic
-	validateAssignments(sl, req)        // 2. Validate Assignments
-	validateNotifications(sl, req)      // 3. Validate Notifications
+	if req.FrequencyMetadata != nil || req.Frequency != nil {
+		validateFrequencyLogic(sl, req) // 1. Validate Frequency Logic
+	}
+	if req.AssignStrategy != "" || req.AssignedTo != nil || len(req.Assignees) > 0 {
+		validateAssignments(sl, req) // 2. Validate Assignments
+	}
+	if req.Notification || req.NotificationMetadata != nil {
+		validateNotifications(sl, req) // 3. Validate Notifications
+	}
 	validateConcurrencyControl(sl, req) // 4. Validate Optimistic Concurrency Control
 }
 
@@ -100,7 +106,7 @@ func validateNotifications(sl validator.StructLevel, req ChoreReq) {
 		}
 	} else if hasNotificationMetadata {
 		// If notifications are disabled (or nil), ensure the client isn't sending unused metadata
-		sl.ReportError(req.NotificationMetadata, "NotificationMetadata", "notificationMetadata", "forbidden_when_notifications_disabled", "")
+		// sl.ReportError(req.NotificationMetadata, "NotificationMetadata", "notificationMetadata", "forbidden_when_notifications_disabled", "")
 	}
 }
 


### PR DESCRIPTION
Add more robust defaulting and validation logic for chore creation and editing, particularly around optional fields such as `isActive`, `isPrivate`, and notification metadata.  making sure we are warning and giving time to update the client before creating breaking changes