### PR TITLE
fix: prevent app crash by fixing nil metadata bypass in chore validation

### DIFF
--- a/internal/chore/validator.go
+++ b/internal/chore/validator.go
@@ -11,7 +11,13 @@ import (
 func ChoreReqStructLevelValidation(sl validator.StructLevel) {
 	req := sl.Current().Interface().(ChoreReq)
 
-	if req.FrequencyMetadata != nil || req.Frequency != nil {
+	// Always validate frequency logic for types that require metadata or frequency fields,
+	// regardless of whether those fields were provided in the request. This prevents
+	// invalid chores from being saved when required fields are omitted entirely.
+	switch req.FrequencyType {
+	case chModel.FrequencyTypeInterval,
+		chModel.FrequencyTypeDayOfTheWeek,
+		chModel.FrequencyTypeDayOfTheMonth:
 		validateFrequencyLogic(sl, req) // 1. Validate Frequency Logic
 	}
 	if req.AssignStrategy != "" || req.AssignedTo != nil || len(req.Assignees) > 0 {


### PR DESCRIPTION
### The Bug 
When creating a chore via `POST /api/v1/chores` with a frequency type that requires metadata (like `interval`), but omitting both `frequency` and `frequencyMetadata` from the request payload, the backend bypasses validation and saves the chore with a `null` metadata field. 

When the React frontend fetches this chore, it crashes the entire app when attempting to render the chore card.

### Steps to Reproduce
1. Send a POST request to `/api/v1/chores` with the following JSON body, omitting both `frequency` and `frequencyMetadata` for an interval chore:
```json
{
  "name": "Poison Pill",
  "priority": 1,
  "points": 1,
  "isPrivate": false,
  "priority": 2,
  "isActive": true,
  "isRolling": false,
  "assignStrategy": "random",
  "assignedTo": 1,
  "assignees": [
    {
      "userId": 1
    }
  ],
  "circleId": 1,
  "status": 0,
  "frequencyType": "interval"
}
```
2. The backend responds with `200 OK` and saves the chore. The API response will look like this:
```json
{
  "res": 2,
  "warnings": [
    "frequency not provided, defaulting to 1"
  ]
}
```
3. Open the web UI. The React app immediately crashes with:
```javascript
TypeError: Cannot read properties of null (reading 'unit')
    at i0e (index-sHu-ireK.js:544:267)
    at o0e (index-sHu-ireK.js:544:5859)
    ...
```

### Root Cause

**Backend:**
The validation logic in `validator.go` previously used a guard condition based on the *presence* of the fields rather than the `frequencyType`:
```go
if req.FrequencyMetadata != nil || req.Frequency != nil {
    validateFrequencyLogic(sl, req) // 1. Validate Frequency Logic
}
```
Because both `req.FrequencyMetadata` and `req.Frequency` are `nil` in the poison pill payload, `validateFrequencyLogic` is completely bypassed. 
Later in the handler, `setCreateChoreDefaults` sets a default `frequency = 1` since it was missing, but leaves `frequencyMetadata` as `nil`. The chore is then saved as an `interval` chore with no metadata, creating the poison pill.

**Frontend:**
In `src/utils/ChoreCardHelpers.jsx`, the frontend assumes that if `frequencyType === 'interval'`, the metadata will always exist:
```javascript
  } else if (chore.frequencyType === 'interval') {
    return `Every ${chore.frequency} ${metadata.unit}` // Crashes here when metadata is null
  }
```

### The Fix
Updated the guard condition in `ChoreReqStructLevelValidation` to use a `switch` statement based on `req.FrequencyType`. 

Now, if the requested frequency type inherently requires frequency validation (like `interval`, `days_of_the_week`, or `day_of_the_month`), the validation logic will always run, regardless of whether the client omitted the fields or not. This correctly catches requests that improperly omit required metadata and returns a `400 Bad Request`.

### Disclosure

I used the assistance of Gemini/Claude to write this report and draft a preliminary fix after finding the bug. :)  I read some good 2 hours of documentations of Go to at least understand if it made sense, correcting the LLM suggestions multiple times before posting it here. Nonetheless, as I am not a GO programmer, i made a mistake haha. And now i corrected it and force pushed so it would fix the right problem. 

Thank you for maintaining Donetick! :)
