### PR TITLE
Use URL-safe base64 for password reset and verification links

### DIFF
--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -504,11 +504,11 @@ func (es *EmailSender) SendResetPasswordEmail(c context.Context, to, code string
 // }
 func encodeEmailAndCode(email, code string) string {
 	data := email + ":" + code
-	return base64.StdEncoding.EncodeToString([]byte(data))
+	return base64.RawURLEncoding.EncodeToString([]byte(data))
 }
 
 func DecodeEmailAndCode(encoded string) (string, string, error) {
-	data, err := base64.StdEncoding.DecodeString(encoded)
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -1,0 +1,30 @@
+package email
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecodeEmailAndCode_RoundTrip(t *testing.T) {
+	cases := []struct{ email, code string }{
+		{"evan@example.com", "abc123"},
+		{"a.b@example.co.uk", "Zm9vYmFyX2Jhei0xMjM"},
+		{"someone+tagged@example.org", "tok_with-url_safe-chars"},
+	}
+	for _, tc := range cases {
+		enc := encodeEmailAndCode(tc.email, tc.code)
+
+		// Must be URL-safe so it survives query parsing untouched (the bug).
+		if strings.ContainsAny(enc, "+/") {
+			t.Fatalf("encoded value contains URL-unsafe chars %q for (%q,%q)", enc, tc.email, tc.code)
+		}
+
+		gotEmail, gotCode, err := DecodeEmailAndCode(enc)
+		if err != nil {
+			t.Fatalf("DecodeEmailAndCode(%q) error: %v", enc, err)
+		}
+		if gotEmail != tc.email || gotCode != tc.code {
+			t.Fatalf("round-trip mismatch: got (%q,%q), want (%q,%q)", gotEmail, gotCode, tc.email, tc.code)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Password-reset and email-verification links fail intermittently with `invalid token`
(form flashes, then redirects to login). `email:code` is encoded with `base64.StdEncoding`
and dropped unescaped into the `?c=` query parameter. A `+` in that value is decoded to a
space by both `URLSearchParams` (frontend) and gin's `c.Query` (backend), corrupting the
token so `UpdatePasswordByToken` matches no row and returns `invalid token`. It only breaks
when a token's base64 happens to contain `+`/`/`, which is why it's intermittent.

## Fix

Switch `encodeEmailAndCode` / `DecodeEmailAndCode` in `internal/email/sender.go` to
`base64.RawURLEncoding` (URL-safe alphabet, no padding), so the value survives query parsing
unchanged. This covers both the reset link and the verification link (single encoder/decoder
pair). No frontend change needed. Added a round-trip unit test.

**Note:** breaking for any reset/verify links already in flight; acceptable since they're short-lived.

Fixes #688