### PR TITLE
fix(auth): make username & email case-insensitive

### DIFF
--- a/internal/user/model/model.go
+++ b/internal/user/model/model.go
@@ -7,7 +7,20 @@ import (
 
 	cModel "donetick.com/core/internal/circle/model"
 	nModel "donetick.com/core/internal/notifier/model"
+	"gorm.io/gorm"
 )
+
+// NormalizeEmail normalises case so the same address always maps to one
+// account, regardless of the case used at signup, login, or by an IdP.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// NormalizeUsername normalises case for IdP-provisioned accounts, which derive
+// the username from a provider id/sub and bypass signup's lowercase check.
+func NormalizeUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
 
 type User struct {
 	ID          int              `json:"id" gorm:"primary_key"`                                                      // Unique identifier
@@ -37,6 +50,15 @@ type User struct {
 	Expiration              *time.Time             `json:"expiration" gorm:"column:expiration;<-:false"`     // read only column
 	UserNotificationTargets UserNotificationTarget `json:"notification_target" gorm:"foreignKey:UserID;references:ID"`
 }
+// BeforeSave is the single chokepoint that keeps stored identity canonical, so
+// unique indexes enforce case-insensitive uniqueness and lookups stay plain
+// equality checks.
+func (u *User) BeforeSave(tx *gorm.DB) error {
+	u.Email = NormalizeEmail(u.Email)
+	u.Username = NormalizeUsername(u.Username)
+	return nil
+}
+
 type UserDetails struct {
 	User
 	WebhookURL *string `json:"webhookURL" gorm:"column:webhook_url;<-:false"` // read only column

--- a/internal/user/repo/repository.go
+++ b/internal/user/repo/repository.go
@@ -89,14 +89,18 @@ func (r *UserRepository) CreateUser(c context.Context, user *uModel.User) (*uMod
 }
 func (r *UserRepository) GetUserByUsername(c context.Context, username string) (*uModel.UserDetails, error) {
 	var user *uModel.UserDetails
+	// Usernames are stored canonicalised (see User.BeforeSave), so we normalise
+	// the lookup input the same way and keep a plain equality match that uses the
+	// unique index — this is what makes login case-insensitive.
+	username = uModel.NormalizeUsername(username)
 	if r.isDonetickDotCom {
 		now := time.Now().UTC()
-		if err := r.db.WithContext(c).Preload("UserNotificationTargets").Table("users u").Select("u.*, s.status as subscription, s.expires_at as expiration, c.webhook_url as webhook_url").Joins("left join subscriptions s on s.circle_id = u.circle_id AND s.status = 'active' AND (s.expires_at IS NULL OR s.expires_at > ?)", now).Joins("left join circles c on c.id = u.circle_id").Where("username = ?", username).First(&user).Error; err != nil {
+		if err := r.db.WithContext(c).Preload("UserNotificationTargets").Table("users u").Select("u.*, s.status as subscription, s.expires_at as expiration, c.webhook_url as webhook_url").Joins("left join subscriptions s on s.circle_id = u.circle_id AND s.status = 'active' AND (s.expires_at IS NULL OR s.expires_at > ?)", now).Joins("left join circles c on c.id = u.circle_id").Where("u.username = ?", username).First(&user).Error; err != nil {
 			return nil, err
 		}
 	} else {
-		// For self-hosted, first get the user without subscription/expiration fields
-		if err := r.db.WithContext(c).Preload("UserNotificationTargets").Table("users u").Select("u.*, c.webhook_url as webhook_url").Joins("left join circles c on c.id = u.circle_id").Where("username = ?", username).First(&user).Error; err != nil {
+		// For self-hosted, first get the user without subscription/expiration fields.
+		if err := r.db.WithContext(c).Preload("UserNotificationTargets").Table("users u").Select("u.*, c.webhook_url as webhook_url").Joins("left join circles c on c.id = u.circle_id").Where("u.username = ?", username).First(&user).Error; err != nil {
 			return nil, err
 		}
 		// Then manually set the subscription status and expiration for self-hosted users
@@ -168,13 +172,20 @@ func (r *UserRepository) UpdateUserCircle(c context.Context, userID, circleID in
 
 func (r *UserRepository) FindByEmail(c context.Context, email string) (*uModel.UserDetails, error) {
 	var user *uModel.UserDetails
-	if err := r.db.WithContext(c).Table("users u").Select("u.*, c.webhook_url as webhook_url").Joins("left join circles c on c.id = u.circle_id").Where("email = ?", email).First(&user).Error; err != nil {
+	// Emails are stored canonicalised (see User.BeforeSave), so an IdP returning
+	// a different-cased address still resolves to the existing account instead of
+	// provisioning a duplicate. Normalise the input and match by equality.
+	email = uModel.NormalizeEmail(email)
+	if err := r.db.WithContext(c).Table("users u").Select("u.*, c.webhook_url as webhook_url").Joins("left join circles c on c.id = u.circle_id").Where("u.email = ?", email).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return user, nil
 }
 
 func (r *UserRepository) SetPasswordResetToken(c context.Context, email, token string) error {
+	// Store the canonical email so the token matches the (canonical) user row
+	// when it is later redeemed, regardless of the case used at either step.
+	email = uModel.NormalizeEmail(email)
 	// confirm user exists with email:
 	user, err := r.FindByEmail(c, email)
 	if err != nil {
@@ -195,6 +206,8 @@ func (r *UserRepository) SetPasswordResetToken(c context.Context, email, token s
 func (r *UserRepository) UpdatePasswordByToken(ctx context.Context, email string, token string, password string) error {
 	logger := logging.FromContext(ctx)
 
+	// Match against the canonical email that was stored when the token was issued.
+	email = uModel.NormalizeEmail(email)
 	logger.Debugw("account.db.UpdatePasswordByToken", "email", email)
 	upr := &uModel.UserPasswordReset{
 		Email: email,

--- a/internal/user/repo/repository_case_insensitive_test.go
+++ b/internal/user/repo/repository_case_insensitive_test.go
@@ -1,0 +1,138 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"donetick.com/core/config"
+	"donetick.com/core/internal/database"
+	uModel "donetick.com/core/internal/user/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestUserRepo(t *testing.T) *UserRepository {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := database.Migration(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewUserRepository(db, &config.Config{IsDoneTickDotCom: false})
+}
+
+func TestCreateUserNormalizesEmailAndUsername(t *testing.T) {
+	r := newTestUserRepo(t)
+	created, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "  Alice  ",
+		DisplayName: "Alice",
+		Email:       "  Alice@Example.COM ",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if created.Username != "alice" {
+		t.Fatalf("persisted username = %q, want alice", created.Username)
+	}
+	if created.Email != "alice@example.com" {
+		t.Fatalf("persisted email = %q, want alice@example.com", created.Email)
+	}
+
+	// Confirm the row on disk is canonical, not just the returned struct.
+	var stored uModel.User
+	if err := r.db.First(&stored, created.ID).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if stored.Username != "alice" || stored.Email != "alice@example.com" {
+		t.Fatalf("stored row not canonical: username=%q email=%q", stored.Username, stored.Email)
+	}
+}
+
+func TestGetUserByUsernameCaseInsensitive(t *testing.T) {
+	r := newTestUserRepo(t)
+	if _, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "alice",
+		DisplayName: "Alice",
+		Email:       "alice@example.com",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	for _, in := range []string{"alice", "Alice", "ALICE", "AlIcE", " alice "} {
+		u, err := r.GetUserByUsername(context.Background(), in)
+		if err != nil {
+			t.Fatalf("lookup %q: %v", in, err)
+		}
+		if u.Username != "alice" {
+			t.Fatalf("lookup %q resolved to %q, want alice", in, u.Username)
+		}
+	}
+}
+
+func TestFindByEmailCaseInsensitive(t *testing.T) {
+	r := newTestUserRepo(t)
+	if _, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "bob",
+		DisplayName: "Bob",
+		Email:       "Bob@Example.com",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	for _, in := range []string{"bob@example.com", "BOB@EXAMPLE.COM", "Bob@Example.com", " bob@example.com "} {
+		u, err := r.FindByEmail(context.Background(), in)
+		if err != nil {
+			t.Fatalf("lookup %q: %v", in, err)
+		}
+		if u.Username != "bob" {
+			t.Fatalf("lookup %q resolved to %q, want bob", in, u.Username)
+		}
+	}
+}
+
+func TestCreateUserRejectsCaseVariantDuplicateEmail(t *testing.T) {
+	r := newTestUserRepo(t)
+	if _, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "carol",
+		DisplayName: "Carol",
+		Email:       "carol@example.com",
+	}); err != nil {
+		t.Fatalf("create first user: %v", err)
+	}
+	if _, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "carol2",
+		DisplayName: "Carol Two",
+		Email:       "CAROL@example.com",
+	}); err == nil {
+		t.Fatal("expected unique-constraint error creating case-variant duplicate email, got nil")
+	}
+}
+
+func TestPasswordResetRoundTripCaseInsensitive(t *testing.T) {
+	r := newTestUserRepo(t)
+	if _, err := r.CreateUser(context.Background(), &uModel.User{
+		Username:    "dave",
+		DisplayName: "Dave",
+		Email:       "dave@example.com",
+		Password:    "old-hash",
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := r.SetPasswordResetToken(context.Background(), "Dave@Example.com", "tok-123"); err != nil {
+		t.Fatalf("set reset token: %v", err)
+	}
+	if err := r.UpdatePasswordByToken(context.Background(), "DAVE@EXAMPLE.COM", "tok-123", "new-hash"); err != nil {
+		t.Fatalf("redeem reset token: %v", err)
+	}
+
+	var stored uModel.User
+	if err := r.db.Where("email = ?", "dave@example.com").First(&stored).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if stored.Password != "new-hash" {
+		t.Fatalf("password not updated, got %q", stored.Password)
+	}
+}

--- a/migrations/20260620_canonicalize_user_identity.go
+++ b/migrations/20260620_canonicalize_user_identity.go
@@ -1,0 +1,82 @@
+package migrations
+
+import (
+	"context"
+
+	uModel "donetick.com/core/internal/user/model"
+	"donetick.com/core/logging"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// CanonicalizeUserIdentity20260620 backfills canonicalisation: usernames and
+// emails are now stored trimmed + lowercased (see User.BeforeSave), so legacy
+// rows are rewritten to match. With the column canonical, the existing unique
+// indexes enforce case-insensitive uniqueness and login lookups stay plain
+// equality checks.
+//
+// Rows whose lowercased value would collide with another existing row are left
+// untouched (lowercasing them would violate the unique index) and logged so an
+// operator can merge the duplicate accounts manually. This keeps startup safe on
+// instances that already accumulated case-variant duplicates.
+type CanonicalizeUserIdentity20260620 struct{}
+
+func (m CanonicalizeUserIdentity20260620) ID() string {
+	return "20260620_canonicalize_user_identity"
+}
+
+func (m CanonicalizeUserIdentity20260620) Description() string {
+	return `Backfill canonical (trimmed, lowercased) usernames and emails for existing users so the persisted value is case-insensitive; skip and log case-variant duplicates that can't be lowercased without violating uniqueness.`
+}
+
+func (m CanonicalizeUserIdentity20260620) Down(ctx context.Context, db *gorm.DB) error {
+	// No-op: canonicalisation is not reversible (the original casing is lost).
+	return nil
+}
+
+func (m CanonicalizeUserIdentity20260620) Up(ctx context.Context, db *gorm.DB) error {
+	log := logging.FromContext(ctx)
+
+	if err := m.canonicalizeColumn(ctx, db, log, "email"); err != nil {
+		return err
+	}
+	if err := m.canonicalizeColumn(ctx, db, log, "username"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// canonicalizeColumn lowercases the given column for every row that does not
+// collide with another row after lowercasing. Collisions are logged and skipped.
+func (m CanonicalizeUserIdentity20260620) canonicalizeColumn(ctx context.Context, db *gorm.DB, log *zap.SugaredLogger, column string) error {
+	// Find values that would collapse onto the same lowercase key (case-variant
+	// duplicates). These can't be lowercased without breaking the unique index.
+	var collisions []string
+	if err := db.WithContext(ctx).Model(&uModel.User{}).
+		Where(column+" != ''").
+		Group("LOWER(" + column + ")").
+		Having("COUNT(*) > 1").
+		Pluck("LOWER("+column+")", &collisions).Error; err != nil {
+		log.Errorf("canonicalize %s: failed to detect collisions: %v", column, err)
+		return err
+	}
+
+	for _, key := range collisions {
+		log.Warnf("canonicalize %s: skipping case-variant duplicate %q — merge these accounts manually", column, key)
+	}
+
+	q := db.WithContext(ctx).Model(&uModel.User{}).
+		Where(column+" != '' AND "+column+" <> LOWER("+column+")")
+	if len(collisions) > 0 {
+		q = q.Where("LOWER("+column+") NOT IN ?", collisions)
+	}
+	if err := q.UpdateColumn(column, gorm.Expr("LOWER("+column+")")).Error; err != nil {
+		log.Errorf("canonicalize %s: failed to backfill: %v", column, err)
+		return err
+	}
+	return nil
+}
+
+func init() {
+	Register(CanonicalizeUserIdentity20260620{})
+}

--- a/migrations/20260620_canonicalize_user_identity_test.go
+++ b/migrations/20260620_canonicalize_user_identity_test.go
@@ -1,0 +1,71 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	uModel "donetick.com/core/internal/user/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMigrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&uModel.User{}); err != nil {
+		t.Fatalf("migrate schema: %v", err)
+	}
+	return db
+}
+
+// seedLegacyUser inserts a canonical user (via the normalising hook) and then
+// rewrites its identity columns with raw SQL to simulate a row that predates the
+// hook — UpdateColumn skips hooks so the mixed case survives.
+func seedLegacyUser(t *testing.T, db *gorm.DB, username, email, legacyUsername, legacyEmail string) int {
+	t.Helper()
+	u := &uModel.User{Username: username, DisplayName: username, Email: email}
+	if err := db.Create(u).Error; err != nil {
+		t.Fatalf("seed user %q: %v", username, err)
+	}
+	if err := db.Model(&uModel.User{}).Where("id = ?", u.ID).
+		UpdateColumns(map[string]interface{}{"username": legacyUsername, "email": legacyEmail}).Error; err != nil {
+		t.Fatalf("rewrite legacy columns for %q: %v", username, err)
+	}
+	return u.ID
+}
+
+func TestCanonicalizeUserIdentityBackfill(t *testing.T) {
+	db := newMigrationTestDB(t)
+
+	// Non-colliding legacy row with mixed-case username and email.
+	keepID := seedLegacyUser(t, db, "keep", "keep@example.com", "Keep", "Keep@Example.com")
+	// An already-canonical row that a mixed-case row will collide with.
+	dupID := seedLegacyUser(t, db, "dup", "dup@example.com", "dup", "dup@example.com")
+	// Legacy row that lowercases onto dup@example.com — must be left untouched.
+	collideID := seedLegacyUser(t, db, "collide", "placeholder@example.com", "Collide", "DUP@example.com")
+
+	if err := (CanonicalizeUserIdentity20260620{}).Up(context.Background(), db); err != nil {
+		t.Fatalf("migration Up: %v", err)
+	}
+
+	get := func(id int) uModel.User {
+		var u uModel.User
+		if err := db.First(&u, id).Error; err != nil {
+			t.Fatalf("reload %d: %v", id, err)
+		}
+		return u
+	}
+
+	if u := get(keepID); u.Email != "keep@example.com" || u.Username != "keep" {
+		t.Fatalf("non-colliding row not canonicalised: username=%q email=%q", u.Username, u.Email)
+	}
+	if u := get(dupID); u.Email != "dup@example.com" {
+		t.Fatalf("canonical row changed unexpectedly: email=%q", u.Email)
+	}
+	if u := get(collideID); u.Email != "DUP@example.com" {
+		t.Fatalf("colliding row was altered (would violate uniqueness): email=%q", u.Email)
+	}
+}


### PR DESCRIPTION
Closes #429

## Problem

Login was case-sensitive. `GetUserByUsername` and `FindByEmail` used exact-match `WHERE` clauses, so a user who typed a different case than they registered with could not log in, and an IdP returning a different-cased email on a later login would provision a duplicate account instead of resolving to the existing one.

## Changes

Identity is canonicalised on write so the stored column is the single source of truth:

- A `User.BeforeSave` hook trims and lowercases `username` and `email` on every create and update. This one chokepoint also covers the IdP provisioning paths, which bypass signup's lowercase validation.
- Lookups normalise their input and match by plain equality (`u.email = ?`). This uses the existing unique indexes instead of a `LOWER(col)` table scan, and lets those indexes enforce case-insensitive uniqueness, so two accounts differing only by case can no longer coexist.
- The password-reset paths normalise email at both issue and redeem, so a token requested in one casing can be redeemed in another.

## Migration

`20260620_canonicalize_user_identity` backfills existing rows to canonical case. It is collision-safe: rows that would lowercase onto an existing value are left untouched and logged (`warn ... merge these accounts manually`) so startup does not fail on instances that already accumulated case-variant duplicates.

Note: collision detection assumes a case-sensitive default collation (SQLite/Postgres). On MySQL with a case-insensitive collation the backfill is effectively a no-op, since uniqueness is already enforced there.

## Tests

- Repo tests: normalize-on-write, case-insensitive username and email lookup, case-variant duplicate rejection, and a password-reset round-trip across casings.
- Migration test: backfill canonicalises non-colliding rows and leaves and logs colliding ones.
