### PR TITLE
feat(auth): add disable_password_auth option for SSO-only instances (#438)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ These features are designed for self-hosted single-household deployments where c
 | `DT_SINGLE_CIRCLE_INSTANCE` | bool | `false` | Hides circle-management UI and disables join/leave/delete-member/accept-request endpoints. New OIDC users are added to a shared household circle (ID 1) instead of getting a personal circle. |
 | `DT_OAUTH2_ADMIN_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `admin` role. |
 | `DT_OAUTH2_MANAGER_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `manager` role. |
+| `DT_DISABLE_PASSWORD_AUTH` | bool | `false` | SSO-only: disables password login. |
 
 ### Role Resolution Rules
 
@@ -245,6 +246,7 @@ Group matching is **exact-string and case-sensitive**.
      - DT_SINGLE_CIRCLE_INSTANCE=true
      - DT_OAUTH2_ADMIN_GROUPS=donetick-admins
      - DT_OAUTH2_MANAGER_GROUPS=donetick-managers
+     - DT_DISABLE_PASSWORD_AUTH=true
    ```
 
 ---

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	FeatureLimits          FeatureLimitsConfig `mapstructure:"feature_limits" yaml:"feature_limits"`
 	Storage                StorageConfig       `mapstructure:"storage" yaml:"storage"`
 	SingleCircleInstance   bool                `mapstructure:"single_circle_instance" yaml:"single_circle_instance"`
+	DisablePasswordAuth    bool                `mapstructure:"disable_password_auth" yaml:"disable_password_auth"`
 	Info                   Info
 }
 

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -68,6 +68,10 @@ oauth2:
 # When true, disables circle join/leave endpoints and adds new OIDC users
 # to a shared household circle instead of creating personal circles.
 # single_circle_instance: false
+# SSO-only mode (optional).
+# When true, all password-based auth (signup, login, reset) is rejected and
+# the login UI hides the password form.
+# disable_password_auth: false
 # Real-time configuration
 realtime:
   enabled: true

--- a/internal/resource/handler.go
+++ b/internal/resource/handler.go
@@ -14,6 +14,9 @@ type Resource struct {
 	APICommit              string           `json:"api_commit" binding:"omitempty"`
 	IsUserCreationDisabled bool             `json:"is_user_creation_disabled"`
 	SingleCircleInstance   bool             `json:"single_circle_instance"`
+	// DisablePasswordAuth tells the client to hide username/password login and
+	// signup, leaving only SSO (#438).
+	DisablePasswordAuth bool `json:"disable_password_auth"`
 }
 type identityProvider struct {
 	Auth_url  string `json:"auth_url" binding:"omitempty"`
@@ -43,6 +46,7 @@ func (h *Handler) getResource(c *gin.Context) {
 		APICommit:              h.config.Info.Commit,
 		IsUserCreationDisabled: h.config.IsUserCreationDisabled,
 		SingleCircleInstance:   h.config.SingleCircleInstance,
+		DisablePasswordAuth:    h.config.DisablePasswordAuth,
 	})
 }
 

--- a/internal/resource/handler_test.go
+++ b/internal/resource/handler_test.go
@@ -1,0 +1,41 @@
+package resource
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"donetick.com/core/config"
+	"github.com/gin-gonic/gin"
+)
+
+// TestResourceExposesDisablePasswordAuth verifies the resource endpoint
+// surfaces the disable_password_auth flag so the client can hide password
+// login (#438).
+func TestResourceExposesDisablePasswordAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, want := range []bool{true, false} {
+		h := NewHandler(&config.Config{DisablePasswordAuth: want})
+		r := gin.New()
+		r.GET("api/v1/resource", h.getResource)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("got %d", w.Code)
+		}
+		var body struct {
+			DisablePasswordAuth bool `json:"disable_password_auth"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.DisablePasswordAuth != want {
+			t.Errorf("disable_password_auth = %v, want %v", body.DisablePasswordAuth, want)
+		}
+	}
+}

--- a/internal/user/disable_password_auth_test.go
+++ b/internal/user/disable_password_auth_test.go
@@ -1,0 +1,64 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestPasswordAuthDisabledGuard verifies the #438 guard: when applied, any
+// password-auth request is rejected with 403 and a clear, SSO-pointing message,
+// before the real handler runs.
+func TestPasswordAuthDisabledGuard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	handlerCalled := false
+	g := r.Group("api/v1/auth")
+	g.Use(passwordAuthDisabled())
+	g.POST("login", func(c *gin.Context) {
+		handlerCalled = true
+		c.JSON(http.StatusOK, gin.H{})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if handlerCalled {
+		t.Fatal("login handler ran despite password auth being disabled")
+	}
+	if !strings.Contains(w.Body.String(), "SSO") {
+		t.Errorf("expected an SSO-pointing message, got %s", w.Body.String())
+	}
+}
+
+// TestPasswordAuthEnabledByDefault confirms the guard is opt-in: without it,
+// the password-auth handler runs normally.
+func TestPasswordAuthEnabledByDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	handlerCalled := false
+	g := r.Group("api/v1/auth")
+	g.POST("login", func(c *gin.Context) {
+		handlerCalled = true
+		c.JSON(http.StatusOK, gin.H{})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if !handlerCalled || w.Code != http.StatusOK {
+		t.Fatalf("expected login handler to run (200), got %d called=%v", w.Code, handlerCalled)
+	}
+}

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -1700,6 +1700,17 @@ func hashToken(token string) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// passwordAuthDisabled rejects password-based auth requests (signup, login,
+// password reset) when the instance is configured as SSO-only via
+// disable_password_auth (#438).
+func passwordAuthDisabled() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error": "Password authentication is disabled on this instance. Please sign in with SSO.",
+		})
+	}
+}
+
 func Routes(router *gin.Engine, h *Handler, jwtAuth *jwt.GinJWTMiddleware, limiter *limiter.Limiter, cfg *config.Config) {
 
 	userRoutes := router.Group("api/v1/users")
@@ -1743,14 +1754,22 @@ func Routes(router *gin.Engine, h *Handler, jwtAuth *jwt.GinJWTMiddleware, limit
 	authRoutes.Use(utils.RateLimitMiddleware(limiter))
 	{
 		authRoutes.POST("/:provider/callback", h.thirdPartyAuthCallback)
-		authRoutes.POST("/", h.signUp)
-		authRoutes.POST("login", authHandler.EnhancedLoginHandler)  // Enhanced login with refresh tokens
-		authRoutes.POST("login/legacy", jwtAuth.LoginHandler)       // Legacy login for backward compatibility
 		authRoutes.POST("refresh", authHandler.RefreshTokenHandler) // Changed from GET to POST
 		authRoutes.POST("logout", authHandler.LogoutHandler)        // New logout endpoint
-		authRoutes.POST("reset", h.resetPassword)
-		authRoutes.POST("password", h.updateUserPassword)
-		authRoutes.POST("mfa/verify", h.verifyMFA) // Add MFA verification endpoint
+		authRoutes.POST("mfa/verify", h.verifyMFA)                  // Add MFA verification endpoint
+
+		// Password-based auth (signup, login, password reset). When
+		// disable_password_auth is set the instance is SSO-only, so these
+		// routes are guarded and reject with 403 (#438).
+		pwAuth := authRoutes.Group("")
+		if cfg.DisablePasswordAuth {
+			pwAuth.Use(passwordAuthDisabled())
+		}
+		pwAuth.POST("/", h.signUp)
+		pwAuth.POST("login", authHandler.EnhancedLoginHandler) // Enhanced login with refresh tokens
+		pwAuth.POST("login/legacy", jwtAuth.LoginHandler)      // Legacy login for backward compatibility
+		pwAuth.POST("reset", h.resetPassword)
+		pwAuth.POST("password", h.updateUserPassword)
 	}
 
 	// Protected auth routes (require JWT)


### PR DESCRIPTION
## Summary

Adds a `disable_password_auth` config flag that makes an instance SSO-only. When it's set, username/password signup, login, and password reset are rejected server-side, and the client is told to hide the password UI. This is option (1) from #438.

Closes #438.

## Changes

- `config/config.go`: new `disable_password_auth` bool (default `false`), overridable via `DT_DISABLE_PASSWORD_AUTH`.
- `internal/user/handler.go`: the password auth routes (`signup`, `login`, `login/legacy`, `reset`, `password`) are moved into a guarded sub-group. When the flag is set, a `passwordAuthDisabled()` middleware short-circuits them with a 403 and a message pointing the user to SSO. Token/SSO routes (`refresh`, `logout`, `mfa/verify`, provider callback) are left untouched.
- `internal/resource/handler.go`: the public `/resource` payload now exposes `disable_password_auth` so the frontend can hide the password UI.

## Enforcement

The backend guard is the real boundary here: it returns 403 even if a client calls the endpoint directly. The `/resource` flag is only a UX hint. Note the flag is read once when routes are registered, so toggling it needs a server restart.

## Behavior with managed sub-accounts

The flag is meant for deployments where every user authenticates through the external IdP. Managed sub-accounts are local password credentials, so they fall under the same guard on purpose: with password auth disabled, no account (primary or sub-account) can log in with a username and password.

That follows option (1) in #438 (SSO for all accounts) rather than option (2) (SSO for primaries, passwords for sub-accounts). Operators who rely on per-family sub-accounts should leave `disable_password_auth` off. Parents can still create and manage sub-accounts on an SSO-only instance, but those credentials won't be usable, which is consistent with the flag's purpose.

## Testing

- `internal/user/disable_password_auth_test.go`: `TestPasswordAuthDisabledGuard` (403 + SSO message when on) and `TestPasswordAuthEnabledByDefault` (login runs, 200, when off).
- `internal/resource/handler_test.go`: verifies `/resource` surfaces the flag.

## Companion PR

Needs the frontend change to hide the password UI: donetick/frontend#121.
