### PR TITLE
Feature/rrule recurrency

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,5 +1,5 @@
 name: "local"
-is_done_tick_dot_com: true
+is_done_tick_dot_com: false
 is_user_creation_disabled: false
 telegram:
   token: ""

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,5 +1,5 @@
 name: "local"
-is_done_tick_dot_com: false
+is_done_tick_dot_com: true
 is_user_creation_disabled: false
 telegram:
   token: ""

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
+	github.com/teambition/rrule-go v1.8.2
 	github.com/ulule/limiter/v3 v3.11.2
 	go.uber.org/fx v1.22.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ github.com/swaggo/gin-swagger v1.6.1 h1:Ri06G4gc9N4t4k8hekMigJ9zKTFSlqj/9paAQCQs
 github.com/swaggo/gin-swagger v1.6.1/go.mod h1:LQ+hJStHakCWRiK/YNYtJOu4mR2FP+pxLnILT/qNiTw=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
+github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
 github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -237,7 +237,7 @@ func (h *Handler) GetChore(c *gin.Context) {
 type ChoreReq struct {
 	ID                   int                           `json:"id"`
 	Name                 string                        `json:"name" binding:"required"`
-	FrequencyType        chModel.FrequencyType         `json:"frequencyType" binding:"required,oneof=once daily weekly monthly yearly adaptive interval days_of_the_week day_of_the_month trigger no_repeat"`
+	FrequencyType        chModel.FrequencyType         `json:"frequencyType" binding:"required,oneof=once hourly daily weekly monthly yearly adaptive trigger no_repeat"`
 	Frequency            *int                          `json:"frequency" binding:"omitempty,gt=0"`
 	FrequencyMetadata    *chModel.FrequencyMetadata    `json:"frequencyMetadata"`
 	NextDueDate          *time.Time                    `json:"nextDueDate" binding:"required_with=IsRolling"` // Next due date in RFC3339 format

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -19,17 +19,20 @@ const MAX_TEMPLATES = 5
 type FrequencyType string
 
 const (
-	FrequencyTypeOnce          FrequencyType = "once"
-	FrequencyTypeDaily         FrequencyType = "daily"
-	FrequencyTypeWeekly        FrequencyType = "weekly"
-	FrequencyTypeMonthly       FrequencyType = "monthly"
-	FrequencyTypeYearly        FrequencyType = "yearly"
-	FrequencyTypeAdaptive      FrequencyType = "adaptive"
+	FrequencyTypeOnce     FrequencyType = "once"
+	FrequencyTypeHourly   FrequencyType = "hourly"
+	FrequencyTypeDaily    FrequencyType = "daily"
+	FrequencyTypeWeekly   FrequencyType = "weekly"
+	FrequencyTypeMonthly  FrequencyType = "monthly"
+	FrequencyTypeYearly   FrequencyType = "yearly"
+	FrequencyTypeAdaptive FrequencyType = "adaptive"
+	FrequencyTypeTrigger  FrequencyType = "trigger"
+	FrequencyTypeNoRepeat FrequencyType = "no_repeat"
+
+	// Deprecated: retired by the unified RRULE model; kept for migration/back-compat reads.
 	FrequencyTypeInterval      FrequencyType = "interval"
 	FrequencyTypeDayOfTheWeek  FrequencyType = "days_of_the_week"
 	FrequencyTypeDayOfTheMonth FrequencyType = "day_of_the_month"
-	FrequencyTypeTrigger       FrequencyType = "trigger"
-	FrequencyTypeNoRepeat      FrequencyType = "no_repeat"
 )
 
 type AssignmentStrategy string
@@ -120,23 +123,46 @@ const (
 	ChoreHistoryStatusRescheduled     ChoreHistoryStatus = 6
 )
 
+// FrequencyMetadata holds the RRULE-equivalent recurrence selectors for a chore.
+// The chore's FrequencyType is the RRULE FREQ (daily/weekly/monthly/yearly) and the
+// chore's Frequency field is the RRULE INTERVAL ("every X"). The fields below map to:
+//
+//	Days      -> BYDAY weekday list (weekly selection, or weekday set for an ordinal rule)
+//	Months    -> BYMONTH (yearly month selection)
+//	MonthDays -> BYMONTHDAY (monthly "Each" mode, days 1-31)
+//	SetPos    -> BYSETPOS ordinals: 1..5, -2 (next to last), -1 (last)
+//	DayToken  -> expands the weekday set for an ordinal rule (see DayToken* constants)
 type FrequencyMetadata struct {
-	Days        []*string    `json:"days,omitempty"`
-	Months      []*string    `json:"months,omitempty"`
-	Unit        *string      `json:"unit" binding:"omitempty,oneof=hours days weeks months years"`
-	Time        string       `json:"time" binding:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	Timezone    string       `json:"timezone" binding:"omitempty,timezone"`
-	WeekPattern *Weekpattern `json:"weekPattern" binding:"omitempty,oneof=every_week week_of_month week_of_quarter"`
-	WeekNumbers []int        `json:"weekNumbers,omitempty"` // DEPRECATED: use Occurrences instead
-	Occurrences []*int       `json:"occurrences,omitempty"` // e.g. ["1","3","last"] for 1st, 3rd, and last occurrence of the day
+	Days      []*string `json:"days,omitempty"`
+	Months    []*string `json:"months,omitempty"`
+	MonthDays []int     `json:"monthDays,omitempty"`                                                       // BYMONTHDAY for monthly "Each" mode (1-31)
+	SetPos    []int     `json:"setPos,omitempty"`                                                          // BYSETPOS ordinals: 1..5, -2 (next to last), -1 (last)
+	DayToken  *string   `json:"dayToken,omitempty" binding:"omitempty,oneof=specific day weekday weekend"` // weekday-set expansion for an ordinal rule
+	Unit      *string   `json:"unit" binding:"omitempty,oneof=hours days weeks months years"`
+	Time      string    `json:"time" binding:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
+	Timezone  string    `json:"timezone" binding:"omitempty,timezone"`
+
+	// DEPRECATED legacy fields, retained so pre-unification chores still deserialize.
+	WeekPattern *Weekpattern `json:"weekPattern,omitempty" binding:"omitempty,oneof=every_week week_of_month week_of_quarter"`
+	WeekNumbers []int        `json:"weekNumbers,omitempty"` // DEPRECATED: use SetPos instead
+	Occurrences []*int       `json:"occurrences,omitempty"` // DEPRECATED: use SetPos instead
 }
+
+// DayToken values expand into the BYDAY weekday set for an ordinal ("On the …") rule.
+const (
+	DayTokenSpecific = "specific" // use the explicitly selected Days
+	DayTokenDay      = "day"      // any day (all 7 weekdays)
+	DayTokenWeekday  = "weekday"  // Monday–Friday
+	DayTokenWeekend  = "weekend"  // Saturday & Sunday
+)
 
 type Weekpattern string
 
+// Deprecated: week patterns are superseded by the unified RRULE model (SetPos + DayToken).
 const (
 	WeekpatternEveryWeek     Weekpattern = "every_week"
-	WeekPatternWeekOfMonth   Weekpattern = "week_of_month"   // e.g. ["1","3","last"] for 1st, 3rd, and last occurrence of the day in the month
-	WeekPatternWeekOfQuarter Weekpattern = "week_of_quarter" // e.g. ["1","2","3"] for 1st, 2nd, and 3rd occurrence of the day in the quarter
+	WeekPatternWeekOfMonth   Weekpattern = "week_of_month"
+	WeekPatternWeekOfQuarter Weekpattern = "week_of_quarter"
 )
 
 type NotificationMetadata struct {

--- a/internal/chore/rrule.go
+++ b/internal/chore/rrule.go
@@ -1,0 +1,188 @@
+package chore
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	chModel "donetick.com/core/internal/chore/model"
+	"github.com/teambition/rrule-go"
+)
+
+// weekdayByName maps lowercase weekday names to rrule weekdays.
+var weekdayByName = map[string]rrule.Weekday{
+	"monday":    rrule.MO,
+	"tuesday":   rrule.TU,
+	"wednesday": rrule.WE,
+	"thursday":  rrule.TH,
+	"friday":    rrule.FR,
+	"saturday":  rrule.SA,
+	"sunday":    rrule.SU,
+}
+
+// monthByName maps lowercase month names to their 1-based number.
+var monthByName = map[string]int{
+	"january": 1, "february": 2, "march": 3, "april": 4,
+	"may": 5, "june": 6, "july": 7, "august": 8,
+	"september": 9, "october": 10, "november": 11, "december": 12,
+}
+
+// freqByType maps a chore FrequencyType to an rrule.Frequency. The boolean is
+// false for non-RRULE-schedulable types (once/trigger/no_repeat/adaptive).
+func freqByType(ft chModel.FrequencyType) (rrule.Frequency, bool) {
+	switch ft {
+	case chModel.FrequencyTypeHourly:
+		return rrule.HOURLY, true
+	case chModel.FrequencyTypeDaily:
+		return rrule.DAILY, true
+	case chModel.FrequencyTypeWeekly:
+		return rrule.WEEKLY, true
+	case chModel.FrequencyTypeMonthly:
+		return rrule.MONTHLY, true
+	case chModel.FrequencyTypeYearly:
+		return rrule.YEARLY, true
+	default:
+		return 0, false
+	}
+}
+
+// isRRuleSchedulable reports whether the chore's frequency is computed via RRULE.
+func isRRuleSchedulable(ft chModel.FrequencyType) bool {
+	_, ok := freqByType(ft)
+	return ok
+}
+
+// buildROption translates a chore's FrequencyType + FrequencyMetadata + interval
+// into an rrule.ROption anchored at dtstart. dtstart carries both the series phase
+// (for INTERVAL) and the time-of-day/timezone of generated occurrences.
+func buildROption(chore *chModel.Chore, dtstart time.Time) (rrule.ROption, error) {
+	freq, ok := freqByType(chore.FrequencyType)
+	if !ok {
+		return rrule.ROption{}, fmt.Errorf("frequency type %q is not RRULE-schedulable", chore.FrequencyType)
+	}
+
+	opt := rrule.ROption{
+		Freq:     freq,
+		Dtstart:  dtstart,
+		Interval: chore.Frequency,
+	}
+	if opt.Interval < 1 {
+		opt.Interval = 1
+	}
+
+	meta := chore.FrequencyMetadataV2
+	if meta == nil {
+		// Bare hourly/daily/weekly/monthly/yearly recurrence anchored at dtstart.
+		return opt, nil
+	}
+
+	switch freq {
+	case rrule.WEEKLY:
+		if len(meta.Days) > 0 {
+			wd, err := weekdays(meta.Days)
+			if err != nil {
+				return rrule.ROption{}, err
+			}
+			opt.Byweekday = wd
+		}
+
+	case rrule.MONTHLY:
+		if len(meta.MonthDays) > 0 {
+			// "Each" mode: specific day numbers of the month.
+			opt.Bymonthday = append([]int(nil), meta.MonthDays...)
+		} else if len(meta.SetPos) > 0 {
+			// "On the" mode: ordinal weekday(s).
+			wd, err := ordinalWeekdays(meta)
+			if err != nil {
+				return rrule.ROption{}, err
+			}
+			opt.Byweekday = wd
+			opt.Bysetpos = append([]int(nil), meta.SetPos...)
+		}
+
+	case rrule.YEARLY:
+		if len(meta.Months) > 0 {
+			mo, err := months(meta.Months)
+			if err != nil {
+				return rrule.ROption{}, err
+			}
+			opt.Bymonth = mo
+		}
+		if len(meta.SetPos) > 0 {
+			// Optional "On the" ordinal block scoped to the selected months.
+			wd, err := ordinalWeekdays(meta)
+			if err != nil {
+				return rrule.ROption{}, err
+			}
+			opt.Byweekday = wd
+			opt.Bysetpos = append([]int(nil), meta.SetPos...)
+		}
+		// With months but no ordinal block, rrule defaults Bymonthday to the
+		// dtstart day-of-month, i.e. the start date's day within each month.
+
+	case rrule.DAILY, rrule.HOURLY:
+		// No additional selectors.
+	}
+
+	return opt, nil
+}
+
+// ordinalWeekdays expands the DayToken + Days of an "On the" ordinal rule into a
+// plain (non-ordinal) weekday set; the ordinal is applied separately via Bysetpos.
+func ordinalWeekdays(meta *chModel.FrequencyMetadata) ([]rrule.Weekday, error) {
+	token := chModel.DayTokenSpecific
+	if meta.DayToken != nil && *meta.DayToken != "" {
+		token = *meta.DayToken
+	}
+	switch token {
+	case chModel.DayTokenDay:
+		return []rrule.Weekday{rrule.MO, rrule.TU, rrule.WE, rrule.TH, rrule.FR, rrule.SA, rrule.SU}, nil
+	case chModel.DayTokenWeekday:
+		return []rrule.Weekday{rrule.MO, rrule.TU, rrule.WE, rrule.TH, rrule.FR}, nil
+	case chModel.DayTokenWeekend:
+		return []rrule.Weekday{rrule.SA, rrule.SU}, nil
+	default: // specific
+		if len(meta.Days) == 0 {
+			return nil, fmt.Errorf("ordinal rule with dayToken 'specific' requires at least one day")
+		}
+		return weekdays(meta.Days)
+	}
+}
+
+// weekdays converts day-name pointers into plain rrule weekdays.
+func weekdays(days []*string) ([]rrule.Weekday, error) {
+	out := make([]rrule.Weekday, 0, len(days))
+	for _, d := range days {
+		if d == nil {
+			continue
+		}
+		wd, ok := weekdayByName[strings.ToLower(strings.TrimSpace(*d))]
+		if !ok {
+			return nil, fmt.Errorf("invalid weekday: %q", *d)
+		}
+		out = append(out, wd)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no valid weekdays provided")
+	}
+	return out, nil
+}
+
+// months converts month-name pointers into 1-based month numbers.
+func months(in []*string) ([]int, error) {
+	out := make([]int, 0, len(in))
+	for _, m := range in {
+		if m == nil {
+			continue
+		}
+		n, ok := monthByName[strings.ToLower(strings.TrimSpace(*m))]
+		if !ok {
+			return nil, fmt.Errorf("invalid month: %q", *m)
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no valid months provided")
+	}
+	return out, nil
+}

--- a/internal/chore/scheduler.go
+++ b/internal/chore/scheduler.go
@@ -5,348 +5,81 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strings"
 	"time"
 
 	chModel "donetick.com/core/internal/chore/model"
 	"donetick.com/core/logging"
+	"github.com/teambition/rrule-go"
 )
 
+// scheduleNextDueDate computes the next due date for a recurring chore using its
+// RRULE-equivalent frequency model. Non-recurring kinds (once/no_repeat/trigger)
+// return nil; adaptive chores are scheduled separately via scheduleAdaptiveNextDueDate.
 func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDate time.Time) (*time.Time, error) {
-	if chore.FrequencyType == "once" || chore.FrequencyType == "no_repeat" || chore.FrequencyType == "trigger" {
+	switch chore.FrequencyType {
+	case chModel.FrequencyTypeOnce, chModel.FrequencyTypeNoRepeat, chModel.FrequencyTypeTrigger:
 		return nil, nil
 	}
 
-	var baseDate time.Time
-	if chore.NextDueDate != nil {
-		baseDate = chore.NextDueDate.UTC()
-	} else {
-		baseDate = completedDate.UTC()
-	}
-	if chore.IsRolling {
-		baseDate = completedDate.UTC()
-	}
-
-	// Handle time-based frequencies, ensure time is in the future
-	if chore.FrequencyType == "day_of_the_month" || chore.FrequencyType == "days_of_the_week" || chore.FrequencyType == "interval" {
-		t, err := time.Parse(time.RFC3339, chore.FrequencyMetadataV2.Time)
-		if err != nil {
-			log := logging.FromContext(ctx)
-			log.Error("error parsing time in frequency metadata", "error", err, "chore_id", chore.ID)
-			log.Warn("falling back to current time for next due date calculation")
-
-			// fallback to use the next due date time if available:
-			if chore.NextDueDate != nil {
-				t = chore.NextDueDate.UTC()
-			} else {
-				t = time.Now().UTC()
-			}
-
-		}
-		t = t.UTC()
-		baseDate = time.Date(baseDate.Year(), baseDate.Month(), baseDate.Day(), t.Hour(), t.Minute(), t.Second(), 0, time.UTC)
-	}
-
-	switch chore.FrequencyType {
-	case "daily":
-		baseDate = baseDate.AddDate(0, 0, 1)
-	case "weekly":
-		baseDate = baseDate.AddDate(0, 0, 7)
-	case "monthly":
-		baseDate = baseDate.AddDate(0, 1, 0)
-	case "yearly":
-		baseDate = baseDate.AddDate(1, 0, 0)
-	case "adaptive":
-		// TODO: Implement a more sophisticated adaptive logic
-		diff := completedDate.UTC().Sub(chore.NextDueDate.UTC())
-		baseDate = completedDate.UTC().Add(diff)
-	case "interval":
-		switch *chore.FrequencyMetadataV2.Unit {
-		case "hours":
-			baseDate = baseDate.Add(time.Duration(chore.Frequency) * time.Hour)
-		case "days":
-			baseDate = baseDate.AddDate(0, 0, chore.Frequency)
-		case "weeks":
-			baseDate = baseDate.AddDate(0, 0, chore.Frequency*7)
-		case "months":
-			baseDate = baseDate.AddDate(0, chore.Frequency, 0)
-		case "years":
-			baseDate = baseDate.AddDate(chore.Frequency, 0, 0)
-		default:
-			return nil, fmt.Errorf("invalid frequency unit: %s", *chore.FrequencyMetadataV2.Unit)
-		}
-	case "days_of_the_week":
-		if len(chore.FrequencyMetadataV2.Days) == 0 {
-			return nil, fmt.Errorf("days_of_the_week requires at least one day")
-		}
-
-		// Handle different week patterns
-		weekPattern := chore.FrequencyMetadataV2.WeekPattern
-
-		// Default to every_week if no pattern specified
-		if weekPattern == nil || *weekPattern == "" || *weekPattern == "every_week" {
-			// Get timezone for calculations - prefer chore timezone, fallback to UTC
-			var loc *time.Location
-			var err error
-			if chore.FrequencyMetadataV2.Timezone != "" {
-				loc, err = time.LoadLocation(chore.FrequencyMetadataV2.Timezone)
-				if err != nil {
-					log := logging.FromContext(ctx)
-					log.Error("error loading timezone from frequency metadata", "error", err, "timezone", chore.FrequencyMetadataV2.Timezone, "chore_id", chore.ID)
-					loc = time.UTC // fallback to UTC
-				}
-			} else {
-				loc = time.UTC
-			}
-
-			// Convert baseDate to the target timezone for weekday calculations
-			baseDateInTimezone := baseDate.In(loc)
-
-			// Find the next valid day of the week in the target timezone
-			for i := 1; i <= 7; i++ {
-				nextDueDateInTimezone := baseDateInTimezone.AddDate(0, 0, i)
-				nextDay := strings.ToLower(nextDueDateInTimezone.Weekday().String())
-				for _, day := range chore.FrequencyMetadataV2.Days {
-					if strings.ToLower(*day) == nextDay {
-						// Convert back to UTC for storage
-						nextDueDateUTC := nextDueDateInTimezone.UTC()
-						return &nextDueDateUTC, nil
-					}
-				}
-			}
-			return nil, fmt.Errorf("no matching day of the week found")
-		}
-
-		// Handle week_of_month pattern
-		if *weekPattern == chModel.WeekPatternWeekOfMonth {
-			occurrences := getOccurrences(chore.FrequencyMetadataV2)
-			if len(occurrences) == 0 {
-				return nil, fmt.Errorf("week_of_month requires at least one occurrence")
-			}
-			return findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, true)
-		}
-
-		// Handle week_of_quarter pattern
-		if *weekPattern == chModel.WeekPatternWeekOfQuarter {
-			occurrences := getOccurrences(chore.FrequencyMetadataV2)
-			if len(occurrences) == 0 {
-				return nil, fmt.Errorf("week_of_quarter requires at least one occurrence")
-			}
-			return findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, false)
-		}
-
-		return nil, fmt.Errorf("invalid week pattern: %s", *weekPattern)
-	case "day_of_the_month":
-		// for day of the month we need to pick the highest between completed date and next due date
-		// when the chore is rolling. i keep forgetting so am writing a detail comment here:
-		// if task due every 15 of jan, and you completed it on the 13 of jan( before the due date ) if we schedule from due date
-		// we will go back to 15 of jan. so we need to pick the highest between the two dates specifically for day of the month
-		if chore.IsRolling && chore.NextDueDate != nil {
-			secondAfterDueDate := chore.NextDueDate.UTC().Add(time.Second)
-			if completedDate.Before(secondAfterDueDate) {
-				baseDate = secondAfterDueDate
-			}
-		}
-		if len(chore.FrequencyMetadataV2.Months) == 0 {
-			return nil, fmt.Errorf("day_of_the_month requires at least one month")
-		}
-		// Ensure the day of the month is valid
-		if chore.Frequency <= 0 || chore.Frequency > 31 {
-			return nil, fmt.Errorf("invalid day of the month: %d", chore.Frequency)
-		}
-
-		// Find the next valid day of the month, considering the year
-		currentMonth := int(baseDate.Month())
-
-		var startFrom int
-		if chore.NextDueDate != nil && baseDate.Month() == chore.NextDueDate.Month() {
-			startFrom = 1
-		}
-
-		for i := startFrom; i < 12+startFrom; i++ { // Start from 0 to check the current month first
-			nextDueDate := baseDate.AddDate(0, i, 0)
-			nextMonth := (currentMonth + i) % 12 // Use modulo to cycle through months
-			if nextMonth == 0 {
-				nextMonth = 12 // Adjust for December
-			}
-
-			// Ensure the target day exists in the month (e.g., Feb 30th is invalid)
-			lastDayOfMonth := time.Date(nextDueDate.Year(), time.Month(nextMonth+1), 0, 0, 0, 0, 0, time.UTC).Day()
-			targetDay := chore.Frequency
-			if targetDay > lastDayOfMonth {
-				targetDay = lastDayOfMonth
-			}
-
-			nextDueDate = time.Date(nextDueDate.Year(), time.Month(nextMonth), targetDay, nextDueDate.Hour(), nextDueDate.Minute(), 0, 0, time.UTC)
-
-			for _, month := range chore.FrequencyMetadataV2.Months {
-				if strings.EqualFold(*month, time.Month(nextMonth).String()) {
-					return &nextDueDate, nil
-				}
-			}
-		}
-		return nil, fmt.Errorf("no matching month found")
-	default:
+	if !isRRuleSchedulable(chore.FrequencyType) {
 		return nil, fmt.Errorf("invalid frequency type: %s", chore.FrequencyType)
 	}
 
-	return &baseDate, nil
+	// Determine the anchor for the next occurrence. Rolling chores re-anchor at
+	// the completion time; otherwise the series continues from the current due
+	// date (falling back to the completion date when no due date is set).
+	anchor := completedDate.UTC()
+	if !chore.IsRolling && chore.NextDueDate != nil {
+		anchor = chore.NextDueDate.UTC()
+	}
+
+	dtstart := rruleDtstart(chore, anchor)
+
+	opt, err := buildROption(chore, dtstart)
+	if err != nil {
+		log := logging.FromContext(ctx)
+		log.Error("error building recurrence rule", "error", err, "chore_id", chore.ID)
+		return nil, err
+	}
+
+	rule, err := rrule.NewRRule(opt)
+	if err != nil {
+		log := logging.FromContext(ctx)
+		log.Error("error constructing rrule", "error", err, "chore_id", chore.ID)
+		return nil, err
+	}
+
+	// First occurrence strictly after the anchor.
+	next := rule.After(dtstart, false)
+	if next.IsZero() {
+		return nil, fmt.Errorf("no next due date found for chore %d", chore.ID)
+	}
+
+	nextUTC := next.UTC()
+	return &nextUTC, nil
 }
 
-// getOccurrences returns the occurrences from metadata, supporting both new and legacy formats
-func getOccurrences(metadata *chModel.FrequencyMetadata) []string {
-	// Prefer new Occurrences field
-	if len(metadata.Occurrences) > 0 {
-		occurrences := make([]string, len(metadata.Occurrences))
-		for i, occ := range metadata.Occurrences {
-			if *occ == -1 {
-				occurrences[i] = "last"
-			} else {
-				occurrences[i] = fmt.Sprintf("%d", *occ)
-			}
-		}
-		return occurrences
-	}
-
-	// Fall back to legacy WeekNumbers for backward compatibility
-	if len(metadata.WeekNumbers) > 0 {
-		occurrences := make([]string, len(metadata.WeekNumbers))
-		for i, week := range metadata.WeekNumbers {
-			occurrences[i] = fmt.Sprintf("%d", week)
-		}
-		return occurrences
-	}
-
-	return []string{}
-}
-
-// findNextDueDateForOccurrencePattern finds the next due date for occurrence-based patterns
-// isMonthly: true for week_of_month, false for week_of_quarter
-func findNextDueDateForOccurrencePattern(baseDate time.Time, days []*string, occurrences []string, isMonthly bool) (*time.Time, error) {
-	// Convert days to a map for faster lookup
-	dayMap := make(map[string]bool)
-	for _, day := range days {
-		dayMap[strings.ToLower(*day)] = true
-	}
-
-	// Convert occurrences to a map for faster lookup
-	occurrenceMap := make(map[string]bool)
-	for _, occ := range occurrences {
-		occurrenceMap[strings.ToLower(occ)] = true
-	}
-
-	// Start searching from the next day
-	currentDate := baseDate.AddDate(0, 0, 1)
-
-	// Limit search to avoid infinite loops (search for up to 2 years)
-	maxSearchDays := 730
-
-	for i := 0; i < maxSearchDays; i++ {
-		dayName := strings.ToLower(currentDate.Weekday().String())
-
-		// Check if this day matches one of our target days
-		if dayMap[dayName] {
-			if isMonthly {
-				// Calculate occurrence within month
-				occurrence := getNthOccurrenceInMonth(currentDate, currentDate.Weekday())
-				if occurrenceMap[fmt.Sprintf("%d", occurrence)] ||
-					(occurrenceMap["last"] && isLastOccurrenceInMonth(currentDate, currentDate.Weekday())) {
-					return &currentDate, nil
-				}
-			} else {
-				// Calculate occurrence within quarter
-				occurrence := getNthOccurrenceInQuarter(currentDate, currentDate.Weekday())
-				if occurrenceMap[fmt.Sprintf("%d", occurrence)] ||
-					(occurrenceMap["last"] && isLastOccurrenceInQuarter(currentDate, currentDate.Weekday())) {
-					return &currentDate, nil
-				}
-			}
-		}
-
-		currentDate = currentDate.AddDate(0, 0, 1)
-	}
-
-	return nil, fmt.Errorf("no matching date found for the specified occurrence pattern")
-}
-
-// getNthOccurrenceInMonth returns which occurrence this is within the month (1-based)
-func getNthOccurrenceInMonth(date time.Time, weekday time.Weekday) int {
-	// Start from the first day of the month
-	firstOfMonth := time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, date.Location())
-
-	// Count occurrences of this weekday up to the given date
-	occurrence := 0
-	for d := firstOfMonth; d.Before(date) || d.Equal(date); d = d.AddDate(0, 0, 1) {
-		if d.Weekday() == weekday {
-			occurrence++
+// rruleDtstart builds the RRULE DTSTART: the anchor date in the chore's timezone,
+// with its time-of-day overridden by the frequency metadata Time when provided.
+func rruleDtstart(chore *chModel.Chore, anchor time.Time) time.Time {
+	loc := time.UTC
+	meta := chore.FrequencyMetadataV2
+	if meta != nil && meta.Timezone != "" {
+		if l, err := time.LoadLocation(meta.Timezone); err == nil {
+			loc = l
 		}
 	}
 
-	return occurrence
-}
-
-// isLastOccurrenceInMonth checks if this is the last occurrence of the weekday in the month
-func isLastOccurrenceInMonth(date time.Time, weekday time.Weekday) bool {
-	// Check if there's another occurrence of this weekday in the same month
-	nextWeek := date.AddDate(0, 0, 7)
-	return nextWeek.Month() != date.Month()
-}
-
-// getNthOccurrenceInQuarter returns which occurrence this is within the quarter (1-based)
-func getNthOccurrenceInQuarter(date time.Time, weekday time.Weekday) int {
-	// Get the first day of the quarter
-	year := date.Year()
-	month := int(date.Month())
-
-	var quarterStartMonth int
-	switch {
-	case month <= 3:
-		quarterStartMonth = 1 // Q1: Jan-Mar
-	case month <= 6:
-		quarterStartMonth = 4 // Q2: Apr-Jun
-	case month <= 9:
-		quarterStartMonth = 7 // Q3: Jul-Sep
-	default:
-		quarterStartMonth = 10 // Q4: Oct-Dec
-	}
-
-	firstOfQuarter := time.Date(year, time.Month(quarterStartMonth), 1, 0, 0, 0, 0, date.Location())
-
-	// Count occurrences of this weekday up to the given date
-	occurrence := 0
-	for d := firstOfQuarter; d.Before(date) || d.Equal(date); d = d.AddDate(0, 0, 1) {
-		if d.Weekday() == weekday {
-			occurrence++
+	dt := anchor.In(loc)
+	if meta != nil && meta.Time != "" {
+		if t, err := time.Parse(time.RFC3339, meta.Time); err == nil {
+			tl := t.In(loc)
+			dt = time.Date(dt.Year(), dt.Month(), dt.Day(), tl.Hour(), tl.Minute(), tl.Second(), 0, loc)
 		}
 	}
-
-	return occurrence
+	return dt
 }
 
-// isLastOccurrenceInQuarter checks if this is the last occurrence of the weekday in the quarter
-func isLastOccurrenceInQuarter(date time.Time, weekday time.Weekday) bool {
-	// Check if there's another occurrence of this weekday in the same quarter
-	nextWeek := date.AddDate(0, 0, 7)
-	if nextWeek.Year() != date.Year() {
-		return true
-	}
-
-	month := int(date.Month())
-	nextMonth := int(nextWeek.Month())
-
-	switch {
-	case month <= 3 && nextMonth > 3:
-		return true
-	case month <= 6 && nextMonth > 6:
-		return true
-	case month <= 9 && nextMonth > 9:
-		return true
-	case month <= 12 && nextMonth > 12:
-		return true
-	}
-
-	return false
-}
 func scheduleAdaptiveNextDueDate(chore *chModel.Chore, completedDate time.Time, history []*chModel.ChoreHistory) (*time.Time, error) {
 
 	history = append([]*chModel.ChoreHistory{

--- a/internal/chore/scheduler_test.go
+++ b/internal/chore/scheduler_test.go
@@ -2,7 +2,6 @@ package chore
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -18,307 +17,259 @@ type scheduleTest struct {
 	wantErrMsg    string
 }
 
-func TestScheduleNextDueDateBasicTests(t *testing.T) {
-	// location, err := time.LoadLocation("America/New_York")
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
-	}
+var utc = time.UTC
 
-	now := time.Date(2025, 1, 2, 0, 15, 0, 0, location)
+// dt is a terse UTC time builder for test expectations.
+func dt(y int, m time.Month, d, h, min int) time.Time {
+	return time.Date(y, m, d, h, min, 0, 0, utc)
+}
+
+// TestScheduleNextDueDateBasic covers bare interval recurrences (no by-rules).
+func TestScheduleNextDueDateBasic(t *testing.T) {
 	tests := []scheduleTest{
 		{
-			name: "Daily",
+			name: "Hourly every 6 hours",
+			chore: chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeHourly,
+				Frequency:     6,
+				NextDueDate:   timePtr(dt(2025, 1, 2, 18, 0)),
+			},
+			want: timePtr(dt(2025, 1, 3, 0, 0)),
+		},
+		{
+			name: "Daily every 1",
+			chore: chModel.Chore{
+				FrequencyType:       chModel.FrequencyTypeDaily,
+				Frequency:           1,
+				NextDueDate:         timePtr(dt(2025, 1, 2, 18, 30)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{Time: "2025-01-02T18:30:00Z"},
+			},
+			want: timePtr(dt(2025, 1, 3, 18, 30)),
+		},
+		{
+			name: "Daily every 2",
 			chore: chModel.Chore{
 				FrequencyType: chModel.FrequencyTypeDaily,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
+				Frequency:     2,
+				NextDueDate:   timePtr(dt(2025, 1, 2, 18, 0)),
 			},
-			completedDate: now,
-			want:          timePtr(now.AddDate(0, 0, 1)),
+			want: timePtr(dt(2025, 1, 4, 18, 0)),
 		},
 		{
-			name: "Daily - (IsRolling)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDaily,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
-				IsRolling: true,
-			},
-			completedDate: now.AddDate(0, 1, 0),
-			want:          timePtr(now.AddDate(0, 1, 1)),
-		},
-		{
-			name: "Weekly",
+			name: "Weekly bare (every 7 days on the due weekday)",
 			chore: chModel.Chore{
 				FrequencyType: chModel.FrequencyTypeWeekly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 2, 10, 0)), // Thursday
 			},
-			completedDate: now,
-			want:          timePtr(now.AddDate(0, 0, 7)),
+			want: timePtr(dt(2025, 1, 9, 10, 0)),
 		},
 		{
-			name: "Weekly - (IsRolling)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeWeekly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
-				IsRolling: true,
-			},
-			completedDate: now.AddDate(1, 0, 0),
-			want:          timePtr(now.AddDate(1, 0, 7)),
-		},
-		{
-			name: "Monthly",
+			name: "Monthly bare every 2 months",
 			chore: chModel.Chore{
 				FrequencyType: chModel.FrequencyTypeMonthly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
+				Frequency:     2,
+				NextDueDate:   timePtr(dt(2025, 1, 15, 10, 0)),
 			},
-			completedDate: now,
-			want:          timePtr(now.AddDate(0, 1, 0)),
+			want: timePtr(dt(2025, 3, 15, 10, 0)),
 		},
 		{
-			name: "Monthly - (IsRolling)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeMonthly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
-				IsRolling: true,
-			},
-			completedDate: now.AddDate(0, 0, 2),
-			want:          timePtr(now.AddDate(0, 1, 2)),
-		},
-		{
-			name: "Yearly",
+			name: "Yearly bare",
 			chore: chModel.Chore{
 				FrequencyType: chModel.FrequencyTypeYearly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 2, 10, 9, 0)),
 			},
-			completedDate: now,
-			want:          timePtr(now.AddDate(1, 0, 0)),
-		},
-		{
-			name: "Yearly - (IsRolling)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeYearly,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2024-07-07T14:30:00-04:00",
-				},
-				IsRolling: true,
-			},
-			completedDate: now.AddDate(0, 0, 2),
-			want:          timePtr(now.AddDate(1, 0, 2)),
+			want: timePtr(dt(2026, 2, 10, 9, 0)),
 		},
 	}
 	executeTestTable(t, tests)
 }
 
-func TestScheduleNextDueDateInterval(t *testing.T) {
-	// location, err := time.LoadLocation("America/New_York")
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
-	}
-
-	now := time.Date(2025, 1, 2, 0, 15, 0, 0, location)
+// TestScheduleNextDueDateWeekly covers weekly weekday selection.
+func TestScheduleNextDueDateWeekly(t *testing.T) {
 	tests := []scheduleTest{
 		{
-			name: "Interval - 2 Days",
+			name: "Weekly on Monday from a Thursday",
 			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeInterval,
-				Frequency:     2,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{ // for backward compatibility
-					Time: "2024-07-07T14:30:00-04:00",
-					Unit: jsonPtr("days"),
-				},
-			},
-			completedDate: now,
-			want:          timePtr(truncateToDay(now.AddDate(0, 0, 2)).Add(18*time.Hour + 30*time.Minute)),
-		},
-		{
-			name: "Interval - 4 Weeks",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeInterval,
-				Frequency:     4,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{ // for backward compatibility
-					Time: "2024-07-07T14:30:00-04:00",
-					Unit: jsonPtr("weeks"), // this is needed for interval calculations
-				},
-			},
-			completedDate: now,
-			want:          timePtr(truncateToDay(now.AddDate(0, 0, 4*7)).Add(18*time.Hour + 30*time.Minute)),
-		},
-		{
-			name: "Interval - 3 Months",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeInterval,
-				Frequency:     3,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{ // for backward compatibility
-					Time: "2024-07-07T14:30:00-04:00", // this is needed for interval calculations
-					Unit: jsonPtr("months"),
-				},
-			},
-			completedDate: now,
-			want:          timePtr(truncateToDay(now.AddDate(0, 3, 0)).Add(18*time.Hour + 30*time.Minute)),
-		},
-		{
-			name: "Interval - 2 Years",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeInterval,
-				Frequency:     2,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{ // for backward compatibility
-					Time: "2024-07-07T14:30:00-04:00", // this is needed for interval calculations
-					Unit: jsonPtr("years"),
-				},
-			},
-			completedDate: now,
-			want:          timePtr(truncateToDay(now.AddDate(2, 0, 0)).Add(18*time.Hour + 30*time.Minute)),
-		},
-	}
-	executeTestTable(t, tests)
-}
-
-func TestScheduleNextDueDateDayOfWeek(t *testing.T) {
-	// location, err := time.LoadLocation("America/New_York")
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
-	}
-
-	now := time.Date(2025, 1, 2, 0, 15, 0, 0, location)
-	tests := []scheduleTest{
-		{
-			name: "Days of the week - next Monday",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				NextDueDate:   timePtr(time.Date(2025, 1, 2, 0, 12, 0, 0, location)),
+				FrequencyType: chModel.FrequencyTypeWeekly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 2, 10, 0)), // Thursday
 				FrequencyMetadataV2: &chModel.FrequencyMetadata{
 					Days: []*string{jsonPtr("monday")},
-					Time: "2025-01-20T01:00:00-05:00",
+					Time: "2025-01-06T10:00:00Z",
 				},
 			},
-			completedDate: now,
-			want: func() *time.Time {
-				// Calculate next Monday at 18:00 EST
-				nextMonday := now.AddDate(0, 0, (int(time.Monday)-int(now.Weekday())+7)%7)
-				// print the nextMonday date and time:
-				fmt.Println("nextMonday:", nextMonday)
-				nextMonday = truncateToDay(nextMonday).Add(6*time.Hour + 0*time.Minute)
-				return &nextMonday
-			}(),
+			want: timePtr(dt(2025, 1, 6, 10, 0)), // next Monday
 		},
-		// {
-		// 	name: "Days of the week - next Monday(IsRolling)",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType:     chModel.FrequencyTypeDayOfTheWeek,
-		// 		IsRolling:         true,
-		// 		FrequencyMetadata: jsonPtr(`{"days": ["monday"], "time": "2025-01-20T01:00:00-05:00"}`),
-		// 	},
-
-		// 	completedDate: now.AddDate(0, 1, 0),
-		// 	want: func() *time.Time {
-		// 		// Calculate next Thursday at 18:00 EST
-		// 		completedDate := now.AddDate(0, 1, 0)
-		// 		nextMonday := completedDate.AddDate(0, 0, (int(time.Monday)-int(completedDate.Weekday())+7)%7)
-		// 		nextMonday = truncateToDay(nextMonday).Add(6*time.Hour + 0*time.Minute)
-		// 		return &nextMonday
-		// 	}(),
-		// },
 	}
 	executeTestTable(t, tests)
 }
 
-func TestScheduleNextDueDateDayOfMonth(t *testing.T) {
-	// location, err := time.LoadLocation("America/New_York")
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
-	}
-
-	now := time.Date(2025, 1, 2, 0, 15, 0, 0, location)
+// TestScheduleNextDueDateMonthly covers Apple "Each" and "On the" monthly modes.
+func TestScheduleNextDueDateMonthly(t *testing.T) {
+	// Jan 2025: Sun 5,12,19,26 | Fri 3,10,17,24,31 | Jan 1 is Wed
 	tests := []scheduleTest{
 		{
-			name: "Day of the month - 15th of January",
+			name: "First Sunday of month",
 			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheMonth,
-				Frequency:     15,
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 5, 10, 0)),
 				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2025-01-20T14:00:00-05:00",
-					Unit: jsonPtr("days"),
-					Months: []*string{
-						jsonPtr("january"),
-					},
+					Days:     []*string{jsonPtr("sunday")},
+					SetPos:   []int{1},
+					DayToken: jsonPtr(chModel.DayTokenSpecific),
+					Time:     "2025-01-05T10:00:00Z",
 				},
 			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 15, 19, 0, 0, 0, location)),
+			want: timePtr(dt(2025, 2, 2, 10, 0)),
 		},
 		{
-			name: "Day of the month - 15th of January(isRolling)",
+			name: "Every 2 months on the first Sunday",
 			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheMonth,
-				Frequency:     15,
-				IsRolling:     true,
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     2,
+				NextDueDate:   timePtr(dt(2025, 1, 5, 10, 0)),
 				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2025-01-20T02:00:00-05:00", // this is needed for interval calculations
-					Unit: jsonPtr("days"),
-					Months: []*string{
-						jsonPtr("january"),
-					},
+					Days:   []*string{jsonPtr("sunday")},
+					SetPos: []int{1},
+					Time:   "2025-01-05T10:00:00Z",
 				},
 			},
-			completedDate: now.AddDate(1, 1, 0),
-			want:          timePtr(time.Date(2027, 1, 15, 7, 0, 0, 0, location)),
+			want: timePtr(dt(2025, 3, 2, 10, 0)),
 		},
-		// test if completed before the 15th of the month:
 		{
-			name: "Day of the month - 15th of January(isRolling)(Completed before due date)",
+			name: "Last Friday of month",
 			chore: chModel.Chore{
-				NextDueDate:   timePtr(time.Date(2025, 1, 15, 18, 0, 0, 0, location)),
-				FrequencyType: chModel.FrequencyTypeDayOfTheMonth,
-				Frequency:     15,
-				IsRolling:     true,
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 31, 17, 0)),
 				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Time: "2025-01-20T18:00:00-05:00", // this is needed for interval calculations
-					Unit: jsonPtr("days"),             // this is needed for interval calculations
-					Months: []*string{
-						jsonPtr("january"),
-					},
+					Days:   []*string{jsonPtr("friday")},
+					SetPos: []int{-1},
+					Time:   "2025-01-31T17:00:00Z",
 				},
 			},
-			completedDate: now.AddDate(0, 0, 2),
-			want:          timePtr(time.Date(2026, 1, 15, 18, 0, 0, 0, location)),
+			want: timePtr(dt(2025, 2, 28, 17, 0)),
+		},
+		{
+			name: "Next-to-last Sunday of month",
+			chore: chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 1, 10, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{
+					Days:   []*string{jsonPtr("sunday")},
+					SetPos: []int{-2},
+					Time:   "2025-01-01T10:00:00Z",
+				},
+			},
+			want: timePtr(dt(2025, 1, 19, 10, 0)),
+		},
+		{
+			name: "First weekday of month (day token)",
+			chore: chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 1, 10, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{
+					DayToken: jsonPtr(chModel.DayTokenWeekday),
+					SetPos:   []int{1},
+					Time:     "2025-01-01T10:00:00Z",
+				},
+			},
+			want: timePtr(dt(2025, 2, 3, 10, 0)), // Feb 1 Sat, 2 Sun, 3 Mon
+		},
+		{
+			name: "Each: 1st and 15th",
+			chore: chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeMonthly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 1, 1, 10, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{
+					MonthDays: []int{1, 15},
+					Time:      "2025-01-01T10:00:00Z",
+				},
+			},
+			want: timePtr(dt(2025, 1, 15, 10, 0)),
 		},
 	}
 	executeTestTable(t, tests)
-
 }
 
-func TestScheduleNextDueDateErrors(t *testing.T) {
-	// location, err := time.LoadLocation("America/New_York")
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
-	}
-
-	now := time.Date(2025, 1, 2, 0, 15, 0, 0, location)
+// TestScheduleNextDueDateYearly covers yearly month selection with/without ordinal.
+func TestScheduleNextDueDateYearly(t *testing.T) {
 	tests := []scheduleTest{
 		{
-			name: "Invalid frequency Metadata",
+			name: "First Sunday of March every 2 years",
 			chore: chModel.Chore{
-				FrequencyType:       "invalid",
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{},
+				FrequencyType: chModel.FrequencyTypeYearly,
+				Frequency:     2,
+				NextDueDate:   timePtr(dt(2025, 3, 2, 10, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{
+					Months: []*string{jsonPtr("march")},
+					Days:   []*string{jsonPtr("sunday")},
+					SetPos: []int{1},
+					Time:   "2025-03-02T10:00:00Z",
+				},
 			},
+			want: timePtr(dt(2027, 3, 7, 10, 0)),
+		},
+		{
+			name: "Yearly in March & June on the start day (no ordinal)",
+			chore: chModel.Chore{
+				FrequencyType: chModel.FrequencyTypeYearly,
+				Frequency:     1,
+				NextDueDate:   timePtr(dt(2025, 3, 21, 10, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{
+					Months: []*string{jsonPtr("march"), jsonPtr("june")},
+					Time:   "2025-03-21T10:00:00Z",
+				},
+			},
+			want: timePtr(dt(2025, 6, 21, 10, 0)),
+		},
+	}
+	executeTestTable(t, tests)
+}
+
+// TestScheduleNextDueDateRolling verifies rolling chores re-anchor at completion.
+func TestScheduleNextDueDateRolling(t *testing.T) {
+	tests := []scheduleTest{
+		{
+			name: "Daily rolling anchors at completion + metadata time",
+			chore: chModel.Chore{
+				FrequencyType:       chModel.FrequencyTypeDaily,
+				Frequency:           1,
+				IsRolling:           true,
+				NextDueDate:         timePtr(dt(2025, 1, 1, 18, 0)),
+				FrequencyMetadataV2: &chModel.FrequencyMetadata{Time: "2025-01-01T18:00:00Z"},
+			},
+			completedDate: dt(2025, 6, 10, 12, 0),
+			want:          timePtr(dt(2025, 6, 11, 18, 0)),
+		},
+	}
+	executeTestTable(t, tests)
+}
+
+func TestScheduleNextDueDateSpecial(t *testing.T) {
+	now := dt(2025, 1, 2, 0, 15)
+	tests := []scheduleTest{
+		{
+			name:          "Once -> no next due",
+			chore:         chModel.Chore{FrequencyType: chModel.FrequencyTypeOnce},
+			completedDate: now,
+			want:          nil,
+		},
+		{
+			name:          "Trigger -> no next due",
+			chore:         chModel.Chore{FrequencyType: chModel.FrequencyTypeTrigger},
+			completedDate: now,
+			want:          nil,
+		},
+		{
+			name:          "Invalid frequency type",
+			chore:         chModel.Chore{FrequencyType: "invalid"},
 			completedDate: now,
 			wantErr:       true,
 			wantErrMsg:    "invalid frequency type: invalid",
@@ -326,37 +277,27 @@ func TestScheduleNextDueDateErrors(t *testing.T) {
 	}
 	executeTestTable(t, tests)
 }
-func TestScheduleNextDueDate(t *testing.T) {
-
-}
 
 func executeTestTable(t *testing.T, tests []scheduleTest) {
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := scheduleNextDueDate(context.TODO(), &tt.chore, tt.completedDate)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("testcase: %s", tt.name)
-				t.Errorf("scheduleNextDueDate() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("scheduleNextDueDate() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
 			if tt.wantErr {
 				if err.Error() != tt.wantErrMsg {
-					t.Errorf("testcase: %s", tt.name)
-					t.Errorf("scheduleNextDueDate() error message = %v, wantErrMsg %v", err.Error(), tt.wantErrMsg)
+					t.Errorf("scheduleNextDueDate() error message = %q, want %q", err.Error(), tt.wantErrMsg)
 				}
 				return
 			}
-
 			if !equalTime(got, tt.want) {
-				t.Errorf("testcase: %s", tt.name)
-				t.Errorf("scheduleNextDueDate() = %v, want %v", got, tt.want)
-
+				t.Errorf("scheduleNextDueDate() = %v, want %v", fmtTime(got), fmtTime(tt.want))
 			}
 		})
 	}
 }
+
 func equalTime(t1, t2 *time.Time) bool {
 	if t1 == nil && t2 == nil {
 		return true
@@ -367,298 +308,15 @@ func equalTime(t1, t2 *time.Time) bool {
 	return t1.Equal(*t2)
 }
 
-func timePtr(t time.Time) *time.Time {
-	return &t
-}
-
-func jsonPtr(s string) *string {
-	return &s
-}
-
-func truncateToDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
-}
-
-func intPtr(i int) *int {
-	return &i
-}
-
-func TestScheduleNextDueDateWeekPatterns(t *testing.T) {
-	location, err := time.LoadLocation("UTC")
-	if err != nil {
-		t.Fatalf("error loading location: %v", err)
+func fmtTime(t *time.Time) string {
+	if t == nil {
+		return "<nil>"
 	}
-
-	// January 2025 calendar:
-	// Sun Mon Tue Wed Thu Fri Sat
-	//           1   2   3   4
-	//  5   6   7   8   9  10  11
-	// 12  13  14  15  16  17  18
-	// 19  20  21  22  23  24  25
-	// 26  27  28  29  30  31
-
-	// Starting from Thursday, January 1, 2025
-	now := time.Date(2025, 1, 1, 10, 0, 0, 0, location)
-
-	tests := []scheduleTest{
-		{
-			name: "1st Monday of month",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("monday")},
-					Time:        "2025-01-06T10:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					Occurrences: []*int{intPtr(1)},
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 6, 10, 0, 0, 0, location)), // First Monday (Jan 6th)
-		},
-		{
-			name: "2nd Tuesday of month",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("tuesday")},
-					Time:        "2025-01-14T14:30:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					Occurrences: []*int{intPtr(2)},
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 14, 14, 30, 0, 0, location)), // Second Tuesday (Jan 14th)
-		},
-		{
-			name: "1st Friday of quarter",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("friday")},
-					Time:        "2025-01-03T09:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfQuarter; return &w }(),
-					Occurrences: []*int{intPtr(1)},
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 3, 9, 0, 0, 0, location)), // First Friday of Q1
-		},
-		{
-			name: "Every week pattern (default behavior)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("wednesday")},
-					Time:        "2025-01-08T16:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekpatternEveryWeek; return &w }(),
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 8, 16, 0, 0, 0, location)), // Next Wednesday
-		},
-		{
-			name: "No week pattern specified (default behavior)",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days: []*string{jsonPtr("saturday")},
-					Time: "2025-01-04T12:00:00Z",
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 4, 12, 0, 0, 0, location)), // Next Saturday
-		},
-		{
-			name: "1st and 3rd Monday of month",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("monday")},
-					Time:        "2025-01-03T08:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					Occurrences: []*int{intPtr(1), intPtr(3)},
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 6, 8, 0, 0, 0, location)), // First Monday (Jan 6th)
-		},
-		{
-			name: "Last Friday of month",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("friday")},
-					Time:        "2025-01-31T17:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					Occurrences: []*int{intPtr(-1)},
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 31, 17, 0, 0, 0, location)), // Last Friday (Jan 31st)
-		},
-		{
-			name: "Error - week_of_month without occurrences",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("monday")},
-					Time:        "2025-01-06T10:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					Occurrences: []*int{},
-				},
-			},
-			completedDate: now,
-			wantErr:       true,
-			wantErrMsg:    "week_of_month requires at least one occurrence",
-		},
-		{
-			name: "Error - week_of_quarter without occurrences",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("friday")},
-					Time:        "2025-01-03T09:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfQuarter; return &w }(),
-					Occurrences: []*int{},
-				},
-			},
-			completedDate: now,
-			wantErr:       true,
-			wantErrMsg:    "week_of_quarter requires at least one occurrence",
-		},
-		{
-			name: "Backward compatibility - legacy WeekNumbers",
-			chore: chModel.Chore{
-				FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-				FrequencyMetadataV2: &chModel.FrequencyMetadata{
-					Days:        []*string{jsonPtr("monday")},
-					Time:        "2025-01-06T10:00:00Z",
-					WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-					WeekNumbers: []int{1}, // This should still work
-				},
-			},
-			completedDate: now,
-			want:          timePtr(time.Date(2025, 1, 6, 10, 0, 0, 0, location)), // First Monday
-		},
-		// {
-		// 	name: "Week of month - 2nd week Tuesday",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("tuesday")},
-		// 			Time:        "2025-01-14T14:30:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-		// 			WeekNumbers: []int{2},
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	want:          timePtr(time.Date(2025, 1, 14, 14, 30, 0, 0, location)), // Second Tuesday (2nd week)
-		// },
-		// {
-		// 	name: "Week of quarter - 1st week Friday",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("friday")},
-		// 			Time:        "2025-01-03T09:00:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfQuarter; return &w }(),
-		// 			WeekNumbers: []int{1},
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	want:          timePtr(time.Date(2025, 1, 3, 9, 0, 0, 0, location)), // First Friday of Q1
-		// },
-		// {
-		// 	name: "Every week pattern (default behavior)",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("wednesday")},
-		// 			Time:        "2025-01-08T16:00:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekpatternEveryWeek; return &w }(),
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	want:          timePtr(time.Date(2025, 1, 8, 16, 0, 0, 0, location)), // Next Wednesday
-		// },
-		// {
-		// 	name: "No week pattern specified (default behavior)",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days: []*string{jsonPtr("saturday")},
-		// 			Time: "2025-01-04T12:00:00Z",
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	want:          timePtr(time.Date(2025, 1, 4, 12, 0, 0, 0, location)), // Next Saturday
-		// },
-		// {
-		// 	name: "Week of month - multiple days and weeks",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("monday"), jsonPtr("friday")},
-		// 			Time:        "2025-01-03T08:00:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-		// 			WeekNumbers: []int{1, 3},
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	want:          timePtr(time.Date(2025, 1, 3, 8, 0, 0, 0, location)), // First Friday (1st week)
-		// },
-		// {
-		// 	name: "Error - week_of_month without week numbers",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("monday")},
-		// 			Time:        "2025-01-06T10:00:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfMonth; return &w }(),
-		// 			WeekNumbers: []int{},
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	wantErr:       true,
-		// 	wantErrMsg:    "week_of_month requires at least one week number",
-		// },
-		// {
-		// 	name: "Error - week_of_quarter without week numbers",
-		// 	chore: chModel.Chore{
-		// 		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
-		// 		FrequencyMetadataV2: &chModel.FrequencyMetadata{
-		// 			Days:        []*string{jsonPtr("friday")},
-		// 			Time:        "2025-01-03T09:00:00Z",
-		// 			WeekPattern: func() *chModel.Weekpattern { w := chModel.WeekPatternWeekOfQuarter; return &w }(),
-		// 			WeekNumbers: []int{},
-		// 		},
-		// 	},
-		// 	completedDate: now,
-		// 	wantErr:       true,
-		// 	wantErrMsg:    "week_of_quarter requires at least one week number",
-		// },
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := scheduleNextDueDate(context.Background(), &tt.chore, tt.completedDate)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("scheduleNextDueDate() expected error but got none")
-					return
-				}
-				if tt.wantErrMsg != "" && err.Error() != tt.wantErrMsg {
-					t.Errorf("scheduleNextDueDate() error = %v, wantErrMsg %v", err.Error(), tt.wantErrMsg)
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("scheduleNextDueDate() error = %v", err)
-				return
-			}
-			if !equalTime(got, tt.want) {
-				t.Errorf("scheduleNextDueDate() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	return t.UTC().Format(time.RFC3339)
 }
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func jsonPtr(s string) *string { return &s }
+
+func intPtr(i int) *int { return &i }

--- a/internal/chore/validator.go
+++ b/internal/chore/validator.go
@@ -27,41 +27,68 @@ func validateFrequencyLogic(sl validator.StructLevel, req ChoreReq) {
 	hasMetadata := req.FrequencyMetadata != nil
 
 	switch req.FrequencyType {
-	case chModel.FrequencyTypeInterval:
-		// Interval must have metadata and a defined unit (hours, days, etc.)
-		if !hasMetadata || req.FrequencyMetadata.Unit == nil {
-			sl.ReportError(req.FrequencyMetadata, "Unit", "unit", "required_with_interval", "")
-		}
-		// Interval requires a frequency value
-		if req.Frequency == nil {
-			sl.ReportError(req.Frequency, "Frequency", "frequency", "required_with_interval", "")
+	case chModel.FrequencyTypeHourly, chModel.FrequencyTypeDaily:
+		// "Every X" interval only; Frequency must be a positive count when provided.
+		if req.Frequency != nil && *req.Frequency < 1 {
+			sl.ReportError(req.Frequency, "Frequency", "frequency", "valid_interval", "")
 		}
 
-	case chModel.FrequencyTypeDayOfTheWeek:
-		// Day of the week requires at least one specified day in the array
+	case chModel.FrequencyTypeWeekly:
+		// Weekly requires at least one selected weekday.
 		if !hasMetadata || len(req.FrequencyMetadata.Days) == 0 {
-			sl.ReportError(req.FrequencyMetadata, "Days", "days", "required_with_day_of_week", "")
+			sl.ReportError(req.FrequencyMetadata, "Days", "days", "required_with_weekly", "")
 		}
-		// Only validate occurrences if a specific monthly or quarterly week pattern is requested
-		if hasMetadata && req.FrequencyMetadata.WeekPattern != nil {
-			pattern := string(*req.FrequencyMetadata.WeekPattern)
-			if pattern == "week_of_month" || pattern == "week_of_quarter" {
-				hasOccurrences := len(req.FrequencyMetadata.Occurrences) > 0 || len(req.FrequencyMetadata.WeekNumbers) > 0
-				if !hasOccurrences {
-					sl.ReportError(req.FrequencyMetadata, "Occurrences", "occurrences", "required_with_week_pattern", "")
+
+	case chModel.FrequencyTypeMonthly:
+		if !hasMetadata {
+			sl.ReportError(req.FrequencyMetadata, "FrequencyMetadata", "frequencyMetadata", "required_with_monthly", "")
+			return
+		}
+		m := req.FrequencyMetadata
+		hasEach := len(m.MonthDays) > 0 // "Each" mode: specific day numbers
+		hasOnThe := len(m.SetPos) > 0   // "On the" mode: ordinal weekday(s)
+		if !hasEach && !hasOnThe {
+			sl.ReportError(m, "MonthDays", "monthDays", "required_with_monthly", "")
+		}
+		if hasEach {
+			for _, d := range m.MonthDays {
+				if d < 1 || d > 31 {
+					sl.ReportError(m, "MonthDays", "monthDays", "valid_month_day", "")
+					break
 				}
 			}
 		}
+		if hasOnThe {
+			validateOrdinalBlock(sl, m)
+		}
 
-	case chModel.FrequencyTypeDayOfTheMonth:
-		// Day of the month requires at least one specified month in the array
+	case chModel.FrequencyTypeYearly:
+		// Yearly requires at least one selected month, with an optional ordinal block.
 		if !hasMetadata || len(req.FrequencyMetadata.Months) == 0 {
-			sl.ReportError(req.FrequencyMetadata, "Months", "months", "required_with_day_of_month", "")
+			sl.ReportError(req.FrequencyMetadata, "Months", "months", "required_with_yearly", "")
+			return
 		}
-		// The struct tag handles min=1, but the upper bound of 31 requires struct-level checking
-		if req.Frequency == nil || *req.Frequency > 31 {
-			sl.ReportError(req.Frequency, "Frequency", "frequency", "valid_day_of_month", "")
+		if len(req.FrequencyMetadata.SetPos) > 0 {
+			validateOrdinalBlock(sl, req.FrequencyMetadata)
 		}
+	}
+}
+
+// validateOrdinalBlock validates an "On the …" ordinal rule (SetPos + DayToken/Days).
+func validateOrdinalBlock(sl validator.StructLevel, m *chModel.FrequencyMetadata) {
+	for _, p := range m.SetPos {
+		// Allowed ordinals: 1..5, -1 (last), -2 (next to last).
+		if p == 0 || p < -2 || p > 5 {
+			sl.ReportError(m, "SetPos", "setPos", "valid_set_pos", "")
+			break
+		}
+	}
+	token := chModel.DayTokenSpecific
+	if m.DayToken != nil && *m.DayToken != "" {
+		token = *m.DayToken
+	}
+	if token == chModel.DayTokenSpecific && len(m.Days) == 0 {
+		sl.ReportError(m, "Days", "days", "required_with_ordinal", "")
 	}
 }
 

--- a/migrations/20260621_unify_frequency_to_rrule.go
+++ b/migrations/20260621_unify_frequency_to_rrule.go
@@ -1,0 +1,184 @@
+package migrations
+
+import (
+	"context"
+	"encoding/json"
+
+	"donetick.com/core/logging"
+	"gorm.io/gorm"
+)
+
+// MigrateUnifyFrequencyToRRule20260621 converts the legacy fragmented frequency
+// types (interval / days_of_the_week / day_of_the_month) into the unified
+// RRULE-equivalent model: FrequencyType becomes the RRULE FREQ
+// (hourly/daily/weekly/monthly/yearly), the `frequency` column becomes the RRULE
+// INTERVAL, and frequency_meta_v2 carries setPos/monthDays/dayToken selectors.
+//
+// daily/weekly/monthly/yearly and the special types (once/trigger/no_repeat/
+// adaptive) are already valid and are left untouched.
+type MigrateUnifyFrequencyToRRule20260621 struct{}
+
+func (m MigrateUnifyFrequencyToRRule20260621) ID() string {
+	return "20260621_unify_frequency_to_rrule"
+}
+
+func (m MigrateUnifyFrequencyToRRule20260621) Description() string {
+	return `Unify legacy interval/days_of_the_week/day_of_the_month frequency types into the RRULE-equivalent model.`
+}
+
+type unifyChoreRow struct {
+	ID                  int     `gorm:"column:id;primary_key"`
+	FrequencyType       string  `gorm:"column:frequency_type"`
+	Frequency           int     `gorm:"column:frequency"`
+	FrequencyMetadataV2 *string `gorm:"column:frequency_meta_v2"`
+}
+
+func (unifyChoreRow) TableName() string { return "chores" }
+
+// Down is intentionally a no-op: the unified model is the new canonical form and
+// the legacy fragmented representation cannot be reconstructed without loss.
+func (m MigrateUnifyFrequencyToRRule20260621) Down(ctx context.Context, db *gorm.DB) error {
+	logging.FromContext(ctx).Info("20260621_unify_frequency_to_rrule is not automatically reversible; skipping Down")
+	return nil
+}
+
+func (m MigrateUnifyFrequencyToRRule20260621) Up(ctx context.Context, db *gorm.DB) error {
+	log := logging.FromContext(ctx)
+
+	if !db.Migrator().HasColumn(&unifyChoreRow{}, "frequency_meta_v2") {
+		log.Info("Column frequency_meta_v2 does not exist, skipping migration")
+		return nil
+	}
+
+	var chores []unifyChoreRow
+	if err := db.Table("chores").Select("id, frequency_type, frequency, frequency_meta_v2").Find(&chores).Error; err != nil {
+		log.Errorf("Failed to fetch chores: %v", err)
+		return err
+	}
+
+	for _, chore := range chores {
+		newType, newFreq, meta, changed := convertLegacyFrequency(chore)
+		if !changed {
+			continue
+		}
+
+		metaJSON, err := json.Marshal(meta)
+		if err != nil {
+			log.Warnf("Chore %d: failed to marshal frequency_meta_v2: %v", chore.ID, err)
+			continue
+		}
+
+		updates := map[string]interface{}{
+			"frequency_type":    newType,
+			"frequency":         newFreq,
+			"frequency_meta_v2": string(metaJSON),
+		}
+		if err := db.Table("chores").Where("id = ?", chore.ID).Updates(updates).Error; err != nil {
+			log.Warnf("Chore %d: failed to update frequency: %v", chore.ID, err)
+			continue
+		}
+		log.Infof("Chore %d: migrated %q -> %q (interval=%d)", chore.ID, chore.FrequencyType, newType, newFreq)
+	}
+	return nil
+}
+
+// convertLegacyFrequency maps a legacy chore row to its unified (type, interval,
+// metadata). The returned bool is false when no conversion is needed.
+func convertLegacyFrequency(chore unifyChoreRow) (string, int, map[string]interface{}, bool) {
+	meta := map[string]interface{}{}
+	if chore.FrequencyMetadataV2 != nil && *chore.FrequencyMetadataV2 != "" {
+		_ = json.Unmarshal([]byte(*chore.FrequencyMetadataV2), &meta)
+	}
+
+	switch chore.FrequencyType {
+	case "interval":
+		unit, _ := meta["unit"].(string)
+		delete(meta, "unit")
+		newType := "daily"
+		switch unit {
+		case "hours":
+			newType = "hourly"
+		case "days":
+			newType = "daily"
+		case "weeks":
+			newType = "weekly"
+		case "months":
+			newType = "monthly"
+		case "years":
+			newType = "yearly"
+		}
+		freq := chore.Frequency
+		if freq < 1 {
+			freq = 1
+		}
+		return newType, freq, meta, true
+
+	case "days_of_the_week":
+		pattern, _ := meta["weekPattern"].(string)
+		setPos := readOccurrences(meta)
+		delete(meta, "weekPattern")
+		delete(meta, "occurrences")
+		delete(meta, "weekNumbers")
+
+		switch pattern {
+		case "week_of_month":
+			meta["setPos"] = setPos
+			meta["dayToken"] = "specific"
+			return "monthly", 1, meta, true
+		case "week_of_quarter":
+			// Approximate: quarter occurrence -> every 3 months. Verify these rows.
+			meta["setPos"] = setPos
+			meta["dayToken"] = "specific"
+			return "monthly", 3, meta, true
+		default: // every_week or unset
+			return "weekly", 1, meta, true
+		}
+
+	case "day_of_the_month":
+		// Legacy stored the day number in the `frequency` column.
+		day := chore.Frequency
+		if day >= 1 && day <= 31 {
+			meta["monthDays"] = []int{day}
+		}
+		if isAllMonths(meta["months"]) {
+			delete(meta, "months")
+			return "monthly", 1, meta, true
+		}
+		return "yearly", 1, meta, true
+	}
+
+	// daily/weekly/monthly/yearly and special types are already canonical.
+	return chore.FrequencyType, chore.Frequency, meta, false
+}
+
+// readOccurrences extracts ordinal positions from the legacy `occurrences` (or
+// `weekNumbers`) JSON field as a []int (e.g. -1 = last).
+func readOccurrences(meta map[string]interface{}) []int {
+	out := []int{}
+	for _, key := range []string{"occurrences", "weekNumbers"} {
+		if raw, ok := meta[key].([]interface{}); ok && len(raw) > 0 {
+			for _, v := range raw {
+				if f, ok := v.(float64); ok {
+					out = append(out, int(f))
+				}
+			}
+			if len(out) > 0 {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// isAllMonths reports whether a legacy `months` value covers all 12 months.
+func isAllMonths(v interface{}) bool {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return false
+	}
+	return len(arr) >= 12
+}
+
+func init() {
+	Register(MigrateUnifyFrequencyToRRule20260621{})
+}

--- a/migrations/20260621_unify_frequency_to_rrule_test.go
+++ b/migrations/20260621_unify_frequency_to_rrule_test.go
@@ -1,0 +1,134 @@
+package migrations
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func metaJSON(t *testing.T, m map[string]interface{}) *string {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	return &s
+}
+
+func TestConvertLegacyFrequency(t *testing.T) {
+	tests := []struct {
+		name      string
+		row       unifyChoreRow
+		wantType  string
+		wantFreq  int
+		wantChng  bool
+		checkMeta func(t *testing.T, m map[string]interface{})
+	}{
+		{
+			name:     "interval hours -> hourly",
+			row:      unifyChoreRow{FrequencyType: "interval", Frequency: 6, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"unit": "hours", "time": "x"})},
+			wantType: "hourly", wantFreq: 6, wantChng: true,
+			checkMeta: func(t *testing.T, m map[string]interface{}) {
+				if _, ok := m["unit"]; ok {
+					t.Error("unit should be removed")
+				}
+			},
+		},
+		{
+			name:     "interval weeks -> weekly",
+			row:      unifyChoreRow{FrequencyType: "interval", Frequency: 4, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"unit": "weeks"})},
+			wantType: "weekly", wantFreq: 4, wantChng: true,
+		},
+		{
+			name:     "days_of_the_week every_week -> weekly",
+			row:      unifyChoreRow{FrequencyType: "days_of_the_week", Frequency: 1, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"days": []string{"monday"}, "weekPattern": "every_week"})},
+			wantType: "weekly", wantFreq: 1, wantChng: true,
+		},
+		{
+			name:     "days_of_the_week week_of_month -> monthly + setPos",
+			row:      unifyChoreRow{FrequencyType: "days_of_the_week", Frequency: 1, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"days": []string{"sunday"}, "weekPattern": "week_of_month", "occurrences": []int{1}})},
+			wantType: "monthly", wantFreq: 1, wantChng: true,
+			checkMeta: func(t *testing.T, m map[string]interface{}) {
+				if !reflect.DeepEqual(toIntSlice(m["setPos"]), []int{1}) {
+					t.Errorf("setPos = %v, want [1]", m["setPos"])
+				}
+				if m["dayToken"] != "specific" {
+					t.Errorf("dayToken = %v, want specific", m["dayToken"])
+				}
+				if _, ok := m["weekPattern"]; ok {
+					t.Error("weekPattern should be removed")
+				}
+			},
+		},
+		{
+			name:     "days_of_the_week week_of_quarter -> monthly interval 3",
+			row:      unifyChoreRow{FrequencyType: "days_of_the_week", Frequency: 1, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"days": []string{"friday"}, "weekPattern": "week_of_quarter", "occurrences": []int{1}})},
+			wantType: "monthly", wantFreq: 3, wantChng: true,
+		},
+		{
+			name:     "day_of_the_month all months -> monthly",
+			row:      unifyChoreRow{FrequencyType: "day_of_the_month", Frequency: 15, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"months": []string{"january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"}})},
+			wantType: "monthly", wantFreq: 1, wantChng: true,
+			checkMeta: func(t *testing.T, m map[string]interface{}) {
+				if !reflect.DeepEqual(toIntSlice(m["monthDays"]), []int{15}) {
+					t.Errorf("monthDays = %v, want [15]", m["monthDays"])
+				}
+				if _, ok := m["months"]; ok {
+					t.Error("months should be removed for all-months case")
+				}
+			},
+		},
+		{
+			name:     "day_of_the_month subset -> yearly",
+			row:      unifyChoreRow{FrequencyType: "day_of_the_month", Frequency: 15, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"months": []string{"january"}})},
+			wantType: "yearly", wantFreq: 1, wantChng: true,
+			checkMeta: func(t *testing.T, m map[string]interface{}) {
+				if !reflect.DeepEqual(toIntSlice(m["monthDays"]), []int{15}) {
+					t.Errorf("monthDays = %v, want [15]", m["monthDays"])
+				}
+			},
+		},
+		{
+			name:     "daily unchanged",
+			row:      unifyChoreRow{FrequencyType: "daily", Frequency: 1},
+			wantType: "daily", wantFreq: 1, wantChng: false,
+		},
+		{
+			name:     "monthly unchanged",
+			row:      unifyChoreRow{FrequencyType: "monthly", Frequency: 1, FrequencyMetadataV2: metaJSON(t, map[string]interface{}{"monthDays": []int{5}})},
+			wantType: "monthly", wantFreq: 1, wantChng: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotFreq, meta, changed := convertLegacyFrequency(tt.row)
+			if gotType != tt.wantType || gotFreq != tt.wantFreq || changed != tt.wantChng {
+				t.Fatalf("convertLegacyFrequency() = (%q, %d, %v), want (%q, %d, %v)",
+					gotType, gotFreq, changed, tt.wantType, tt.wantFreq, tt.wantChng)
+			}
+			if tt.checkMeta != nil {
+				tt.checkMeta(t, meta)
+			}
+		})
+	}
+}
+
+// toIntSlice normalizes a JSON-decoded numeric slice (which may be []interface{}
+// of float64, or []int) into []int for comparison.
+func toIntSlice(v interface{}) []int {
+	switch s := v.(type) {
+	case []int:
+		return s
+	case []interface{}:
+		out := make([]int, 0, len(s))
+		for _, e := range s {
+			if f, ok := e.(float64); ok {
+				out = append(out, int(f))
+			}
+		}
+		return out
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Unifies Donetick's recurrence engine into a single iCalendar **RRULE**-based model, replacing the fragmented `interval` / `days_of_the_week` / `day_of_the_month` frequency types. This lets the repeat menu express Apple-Calendar-style rules: every _N_ days/weeks/months/years, the _nth_/last weekday of a month, specific days-of-month, multi-month yearly schedules, and day-tokens (day / weekday / weekend day).

## Motivation

The current recurrence options are solid for simple cases but can't express a lot of everyday schedules. Because the frequency types are separate and don't compose, there's no way to say "every 2 months on the first Sunday", limit a weekday rule to specific months, or use ordinals like "fifth" or "next to last" — patterns most calendar apps support out of the box. This came up in donetick/donetick#380 ("Repeat every X months on a specific weekday, like Google"), and more broadly in donetick/donetick#653.

This PR reworks recurrence onto the standard iCalendar **RRULE** model, which covers those cases cleanly and brings the repeat menu in line with what people expect from tools like Apple/Google Calendar. I think this is a meaningful UX upgrade and would love to see it merged into main — happy to iterate on the approach or the presentation if there are any concerns.


## What changed

- **`internal/chore/rrule.go`** (new) — translates `FrequencyType` + `FrequencyMetadata` + interval into a [`teambition/rrule-go`](https://github.com/teambition/rrule-go) `ROption` (FREQ / INTERVAL / BYDAY / BYSETPOS / BYMONTH / BYMONTHDAY). `FrequencyType` is now the RRULE FREQ; the `frequency` column is the INTERVAL.
- **`scheduler.go`** — `scheduleNextDueDate` computes the next occurrence via RRULE; rolling chores re-anchor at completion. Removed the hand-rolled occurrence helpers.
- **`model.go`** — added `monthDays` / `setPos` / `dayToken` to `FrequencyMetadata`; added an `hourly` FREQ; retired the three legacy types (kept as deprecated constants for migration/back-compat reads).
- **`validator.go`** / **`handler.go`** — validation and request binding updated for the unified model.
- **Migration `20260621_unify_frequency_to_rrule`** — hard-converts all existing chores to the new model on startup.

## ⚠️  Breaking change + migration

- The API no longer accepts `interval` / `days_of_the_week` / `day_of_the_month` frequency types — **must be deployed together with the frontend PR** (see below).
- The included migration is **one-way** (`Down` is a no-op). `week_of_quarter` chores map **approximately** to `monthly, interval=3` — verify those rows. Run against a DB copy first.
- Time-of-day (`frequencyMetadata.time`) is now honored consistently across **all** repeating frequencies (previously only the advanced types).

## Testing

- `go test ./internal/chore/... ./migrations/...` — RRULE parity matrix (first/last/next-to-last weekday, every-N months/years, day-tokens, "Each" days, yearly months, rolling) + migration mapping tests.
- `golangci-lint run` clean on changed packages.

## Related

- Frontend PR: [#122](https://github.com/donetick/frontend/pull/122)