### PR TITLE
feat(config): support custom configuration file path via the command line

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/mcuadros/go-defaults"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -325,43 +326,70 @@ func LoadConfig() *Config {
 	// https://github.com/spf13/viper/issues/1895#issuecomment-3316091229
 	viper.SetOptions(viper.ExperimentalBindStruct())
 
-	// set the config name based on the environment:
-	switch env := os.Getenv("DT_ENV"); env {
-	case "local":
-		viper.SetConfigName("local")
-	case "prod":
-		viper.SetConfigName("prod")
-	case "selfhosted":
-		viper.SetConfigName("selfhosted")
-	case "r2":
-		viper.SetConfigName("r2")
-	default:
-		viper.SetConfigName("local")
-	}
-	// get logger and log the current environment:
-	fmt.Printf("--ConfigLoad config for environment: %s\n", os.Getenv("DT_ENV"))
 	viper.SetEnvPrefix("DT")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
-	viper.AddConfigPath("./config")
-	viper.SetConfigType("yaml")
+	if pflag.CommandLine.Lookup("config") == nil {
+		pflag.StringP("config", "c", "", "path to config file")
+	}
+	if !pflag.Parsed() {
+		pflag.Parse()
+	}
+	_ = viper.BindPFlag("config", pflag.CommandLine.Lookup("config"))
 
-	err := viper.ReadInConfig()
-	// print a useful error:
-	if err != nil {
-		var configNotFoundError viper.ConfigFileNotFoundError
-		if errors.As(err, &configNotFoundError) {
-			fmt.Printf("Config file not found, using defaults and environment variables")
-		} else {
-			fmt.Printf("Error reading config file: %v", err)
-			panic(err)
+	configPath := viper.GetString("config")
+
+	configLoaded := false
+	if configPath != "" {
+		if _, err := os.Stat(configPath); err == nil {
+			viper.SetConfigFile(configPath)
+			err = viper.ReadInConfig()
+			if err != nil {
+				fmt.Printf("Error reading config file: %v\n", err)
+				panic(err)
+			}
+			configLoaded = true
+			fmt.Printf("--ConfigLoad config from file: %s\n", configPath)
+		}
+	}
+
+	if !configLoaded {
+		// set the config name based on the environment:
+		switch env := os.Getenv("DT_ENV"); env {
+		case "local":
+			viper.SetConfigName("local")
+		case "prod":
+			viper.SetConfigName("prod")
+		case "selfhosted":
+			viper.SetConfigName("selfhosted")
+		case "r2":
+			viper.SetConfigName("r2")
+		default:
+			viper.SetConfigName("local")
+		}
+		// get logger and log the current environment:
+		fmt.Printf("--ConfigLoad config for environment: %s\n", os.Getenv("DT_ENV"))
+
+		viper.AddConfigPath("./config")
+		viper.SetConfigType("yaml")
+
+		err := viper.ReadInConfig()
+		// print a useful error:
+		if err != nil {
+			var configNotFoundError viper.ConfigFileNotFoundError
+			if errors.As(err, &configNotFoundError) {
+				fmt.Printf("Config file not found, using defaults and environment variables")
+			} else {
+				fmt.Printf("Error reading config file: %v", err)
+				panic(err)
+			}
 		}
 	}
 	// Override with environment variables if set:
 	viper.AutomaticEnv()
 
 	var config Config
-	err = viper.Unmarshal(&config)
+	err := viper.Unmarshal(&config)
 	if err != nil {
 		panic(err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig_FromCommandLine(t *testing.T) {
+	// Backup os.Args and DT_ENV
+	origArgs := os.Args
+	origEnv := os.Getenv("DT_ENV")
+	origCommandLine := pflag.CommandLine
+
+	// Get current working directory to restore later
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get wd: %v", err)
+	}
+	// Change working directory to the repository root so relative paths like "./config" work
+	if err := os.Chdir(".."); err != nil {
+		t.Fatalf("failed to change wd: %v", err)
+	}
+
+	defer func() {
+		os.Args = origArgs
+		os.Setenv("DT_ENV", origEnv)
+		pflag.CommandLine = origCommandLine
+		_ = os.Chdir(currentDir)
+		viper.Reset()
+	}()
+
+	// Create a temp directory for config files
+	tempDir, err := os.MkdirTemp("", "config_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a temp config file
+	testConfigContent := `
+name: "test-custom-config"
+jwt:
+  secret: "a_very_secure_secret_that_is_at_least_32_chars_long_and_not_weak_12345!"
+`
+	tempFile := filepath.Join(tempDir, "custom.yaml")
+	if err := os.WriteFile(tempFile, []byte(testConfigContent), 0644); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+
+	// 1. Test --config flag
+	os.Args = []string{"cmd", "--config", tempFile}
+	pflag.CommandLine = pflag.NewFlagSet("cmd", pflag.ContinueOnError)
+	viper.Reset()
+	cfgFlag := LoadConfig()
+	assert.Equal(t, "test-custom-config", cfgFlag.Name)
+
+	// 2. Test -c flag
+	os.Args = []string{"cmd", "-c", tempFile}
+	pflag.CommandLine = pflag.NewFlagSet("cmd", pflag.ContinueOnError)
+	viper.Reset()
+	cfgShorthand := LoadConfig()
+	assert.Equal(t, "test-custom-config", cfgShorthand.Name)
+
+	// 3. Test fallback when file does not exist or flag is empty
+	os.Args = []string{"cmd", "--config", "non_existent_file.yaml"}
+	os.Setenv("DT_ENV", "local")
+	pflag.CommandLine = pflag.NewFlagSet("cmd", pflag.ContinueOnError)
+	viper.Reset()
+	cfgFallback := LoadConfig()
+	assert.NotEmpty(t, cfgFallback.Name)
+}


### PR DESCRIPTION
## Summary

Adds support for specifying a custom configuration file path via the first command-line argument (`argv[1]`). If the argument is not provided, or if the file does not exist, the application falls back to the original environment-based configuration loading logic.

## Changes

* Modified configuration loading behaviour with fallback to existing behaviour
* Extended test suite
