### PR TITLE
feat(config): support setting the server listening host/IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ These features are designed for self-hosted single-household deployments where c
 | `DT_OAUTH2_ADMIN_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `admin` role. |
 | `DT_OAUTH2_MANAGER_GROUPS` | comma-separated strings | *(empty)* | OIDC group names that grant the `manager` role. |
 | `DT_DISABLE_PASSWORD_AUTH` | bool | `false` | SSO-only: disables password login. |
+| `DT_SERVER_HOST` | string | *(empty)* | The listening host/IP address for the server. If empty, binds to all interfaces. |
 
 ### Role Resolution Rules
 

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,7 @@ type JwtConfig struct {
 }
 
 type ServerConfig struct {
+	Host             string        `mapstructure:"host" yaml:"host"`
 	Port             int           `mapstructure:"port" yaml:"port" default:"2021"`
 	RatePeriod       time.Duration `mapstructure:"rate_period" yaml:"rate_period" default:"60s"`
 	RateLimit        int           `mapstructure:"rate_limit" yaml:"rate_limit" default:"300"`

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -22,6 +22,7 @@ jwt:
   session_time: 1h        # Token valid for 1 hour (access token lifetime)
   max_refresh: 24h       # Can refresh for 24 hours from original login (24h)
 server:
+  host: "" # listening IP address (e.g. "127.0.0.1" or "0.0.0.0"). If empty, defaults to all interfaces.
   port: 2021
   read_timeout: 10s
   write_timeout: 10s

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -19,6 +19,7 @@ jwt:
   session_time: 168h # 7 days
   max_refresh: 1440h # 60 days 
 server:
+  host: "" # listening IP address (e.g. "127.0.0.1" or "0.0.0.0"). If empty, defaults to all interfaces.
   port: 2021
   read_timeout: 10s
   write_timeout: 10s

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, notifier *notif
 	r := gin.New()
 
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
+		Addr:         fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
 		Handler:      r,
 		ReadTimeout:  cfg.Server.ReadTimeout,
 		WriteTimeout: cfg.Server.WriteTimeout,


### PR DESCRIPTION
## Summary

Adds support for specifying a custom listening host/IP address (bind address) for the HTTP server. If not specified, it falls back to binding to all interfaces. When self-hosting behind a reverse proxy, it makes sense to listen on 127.0.0.1. It may also make sense to listen on a separate interface which is what I'll need to be doing.

## Changes

* Added `host` option to `ServerConfig`
* Updated HTTP server initialization to bind to the configured host
* Extended self-hosted and local configuration files and README documentation
