### PR TITLE
Send reminders to all circle members for chores assigned to "Anyone"

### DIFF
--- a/internal/notifier/service/planner.go
+++ b/internal/notifier/service/planner.go
@@ -27,6 +27,11 @@ func NewNotificationPlanner(nr *nRepo.NotificationRepository, cr *cRepo.CircleRe
 func (n *NotificationPlanner) GenerateNotifications(c context.Context, chore *chModel.Chore) bool {
 	log := logging.FromContext(c)
 	circleMembers, err := n.cRepo.GetCircleUsers(c, chore.CircleID)
+	if err != nil {
+		log.Error("Error getting circle members", err)
+		return false
+	}
+
 	var assignedUser *cModel.UserCircleDetail
 	for _, member := range circleMembers {
 		if chore.AssignedTo != nil && *chore.AssignedTo == member.UserID {
@@ -35,10 +40,6 @@ func (n *NotificationPlanner) GenerateNotifications(c context.Context, chore *ch
 		}
 	}
 
-	if err != nil {
-		log.Error("Error getting circle members", err)
-		return false
-	}
 	n.nRepo.DeleteAllChoreNotifications(chore.ID)
 	notifications := make([]*nModel.Notification, 0)
 	if !chore.Notification || chore.FrequencyType == "trigger" {
@@ -50,17 +51,44 @@ func (n *NotificationPlanner) GenerateNotifications(c context.Context, chore *ch
 		return true
 	}
 
-	if len(chore.NotificationMetadataV2.Templates) > 0 && assignedUser != nil {
-		notifications = append(notifications, generateNotificationsFromTemplate(chore, assignedUser, nil)...)
+	if len(chore.NotificationMetadataV2.Templates) > 0 {
+		if assignedUser != nil {
+			notifications = append(notifications, generateNotificationsFromTemplate(chore, assignedUser, assignedUser, nil)...)
+		} else {
+			// A chore assigned to "Anyone" has no assigned user to resolve, which previously
+			// meant no notifications were generated at all. Remind every circle member who
+			// can actually receive one instead.
+			for _, member := range notifiableMembers(circleMembers) {
+				notifications = append(notifications, generateNotificationsFromTemplate(chore, member, nil, nil)...)
+			}
+		}
 	}
 
 	if chore.NotificationMetadataV2.CircleGroup && assignedUser != nil {
-		notifications = append(notifications, generateNotificationsFromTemplate(chore, assignedUser, chore.NotificationMetadataV2.CircleGroupID)...)
+		notifications = append(notifications, generateNotificationsFromTemplate(chore, assignedUser, assignedUser, chore.NotificationMetadataV2.CircleGroupID)...)
 	}
 
 	log.Debug("Generated notifications", "count", len(notifications))
 	n.nRepo.BatchInsertNotifications(notifications)
 	return true
+}
+
+// notifiableMembers returns the circle members that can actually receive a notification.
+// Pending join requests (is_active=false, see CircleRepository.GetPendingJoinRequests) are
+// not members yet, and members without a delivery target would be dropped by the senders,
+// so neither should have notification rows created for them.
+func notifiableMembers(circleMembers []*cModel.UserCircleDetail) []*cModel.UserCircleDetail {
+	members := make([]*cModel.UserCircleDetail, 0, len(circleMembers))
+	for _, member := range circleMembers {
+		if !member.IsActive {
+			continue
+		}
+		if member.NotificationType == nModel.NotificationPlatformNone || member.TargetID == "" {
+			continue
+		}
+		members = append(members, member)
+	}
+	return members
 }
 
 func getEventTypeFromTemplate(template *chModel.NotificationTemplate) EventType {
@@ -104,14 +132,26 @@ func calculateScheduledTime(baseTime time.Time, template *chModel.NotificationTe
 	return baseTime.Add(duration), nil
 }
 
-func generateNotificationsFromTemplate(chore *chModel.Chore, assignedUser *cModel.UserCircleDetail, overrideTarget *int64) []*nModel.Notification {
+// generateNotificationsFromTemplate builds the scheduled notifications for one recipient.
+// assignedUser is who the chore is assigned to and is only used for the message wording; it
+// is nil for a chore assigned to "Anyone", where recipient is each circle member in turn.
+func generateNotificationsFromTemplate(chore *chModel.Chore, recipient *cModel.UserCircleDetail, assignedUser *cModel.UserCircleDetail, overrideTarget *int64) []*nModel.Notification {
 	if len(chore.NotificationMetadataV2.Templates) == 0 {
 		return nil // No templates to process
 	}
-	targetID := assignedUser.TargetID
+	targetID := recipient.TargetID
 	if overrideTarget != nil {
 		targetID = fmt.Sprint(*overrideTarget)
 	}
+
+	text := fmt.Sprintf("📅 Reminder: *%s* is due today and can be completed by anyone.", chore.Name)
+	var assigneeName, assigneeUsername string
+	if assignedUser != nil {
+		assigneeName = assignedUser.DisplayName
+		assigneeUsername = assignedUser.Username
+		text = fmt.Sprintf("📅 Reminder: *%s* is due today and assigned to %s.", chore.Name, assignedUser.DisplayName)
+	}
+
 	notifications := make([]*nModel.Notification, 0)
 
 	for _, template := range chore.NotificationMetadataV2.Templates {
@@ -131,18 +171,18 @@ func generateNotificationsFromTemplate(chore *chModel.Chore, assignedUser *cMode
 			IsSent:       false,
 			ScheduledFor: scheduledTime,
 			CreatedAt:    time.Now().UTC(),
-			TypeID:       assignedUser.NotificationType,
-			UserID:       assignedUser.UserID,
-			CircleID:     assignedUser.CircleID,
+			TypeID:       recipient.NotificationType,
+			UserID:       recipient.UserID,
+			CircleID:     recipient.CircleID,
 			TargetID:     targetID,
-			Text:         fmt.Sprintf("📅 Reminder: *%s* is due today and assigned to %s.", chore.Name, assignedUser.DisplayName),
+			Text:         text,
 			RawEvent: map[string]interface{}{
 				"id":                chore.ID,
 				"type":              eventType,
 				"name":              chore.Name,
 				"due_date":          chore.NextDueDate,
-				"assignee":          assignedUser.DisplayName,
-				"assignee_username": assignedUser.Username,
+				"assignee":          assigneeName,
+				"assignee_username": assigneeUsername,
 			},
 		})
 

--- a/internal/notifier/service/planner_test.go
+++ b/internal/notifier/service/planner_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	chModel "donetick.com/core/internal/chore/model"
+	cModel "donetick.com/core/internal/circle/model"
+	nModel "donetick.com/core/internal/notifier/model"
+)
+
+func member(userID int, active bool, platform nModel.NotificationPlatform, targetID string) *cModel.UserCircleDetail {
+	return &cModel.UserCircleDetail{
+		UserCircle: cModel.UserCircle{
+			UserID:   userID,
+			CircleID: 5,
+			IsActive: active,
+		},
+		Username:         "user",
+		DisplayName:      "User",
+		NotificationType: platform,
+		TargetID:         targetID,
+	}
+}
+
+// choreDueTomorrow builds a chore with a single due-date template. The due date must be in
+// the future or generateNotificationsFromTemplate skips the template as already passed.
+func choreDueTomorrow() *chModel.Chore {
+	dueDate := time.Now().UTC().Add(24 * time.Hour)
+	return &chModel.Chore{
+		ID:           7,
+		Name:         "Take out trash",
+		CircleID:     5,
+		Notification: true,
+		NextDueDate:  &dueDate,
+		NotificationMetadataV2: &chModel.NotificationMetadata{
+			Templates: []*chModel.NotificationTemplate{
+				{Value: 0, Unit: chModel.NotificationTemplateUnitDay},
+			},
+		},
+	}
+}
+
+func TestNotifiableMembersFiltersUndeliverableRecipients(t *testing.T) {
+	// Only members who are approved and have a delivery target should receive rows.
+	eligible := member(1, true, nModel.NotificationPlatformPushover, "pushover-key")
+	pendingJoinRequest := member(2, false, nModel.NotificationPlatformPushover, "pushover-key")
+	noPlatform := member(3, true, nModel.NotificationPlatformNone, "some-target")
+	noTarget := member(4, true, nModel.NotificationPlatformTelegram, "")
+
+	got := notifiableMembers([]*cModel.UserCircleDetail{
+		eligible, pendingJoinRequest, noPlatform, noTarget,
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 notifiable member, got %d", len(got))
+	}
+	if got[0].UserID != eligible.UserID {
+		t.Errorf("expected user %d, got %d", eligible.UserID, got[0].UserID)
+	}
+}
+
+func TestNotifiableMembersEmptyCircle(t *testing.T) {
+	if got := notifiableMembers(nil); len(got) != 0 {
+		t.Errorf("expected no members, got %d", len(got))
+	}
+}
+
+func TestGenerateNotificationsFromTemplateUnassignedTargetsRecipient(t *testing.T) {
+	// For an "Anyone" chore there is no assigned user, so the notification must be
+	// addressed to the recipient and must not claim to be assigned to anyone.
+	recipient := member(3, true, nModel.NotificationPlatformPushover, "recipient-key")
+
+	notifications := generateNotificationsFromTemplate(choreDueTomorrow(), recipient, nil, nil)
+
+	if len(notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifications))
+	}
+	got := notifications[0]
+
+	if got.UserID != recipient.UserID {
+		t.Errorf("expected UserID %d, got %d", recipient.UserID, got.UserID)
+	}
+	if got.TargetID != recipient.TargetID {
+		t.Errorf("expected TargetID %q, got %q", recipient.TargetID, got.TargetID)
+	}
+	if got.TypeID != recipient.NotificationType {
+		t.Errorf("expected TypeID %d, got %d", recipient.NotificationType, got.TypeID)
+	}
+	if got.CircleID != recipient.CircleID {
+		t.Errorf("expected CircleID %d, got %d", recipient.CircleID, got.CircleID)
+	}
+	if got.Text != "📅 Reminder: *Take out trash* is due today and can be completed by anyone." {
+		t.Errorf("unexpected unassigned text: %q", got.Text)
+	}
+	// Webhook consumers read these keys, so they must still be present, just empty.
+	if got.RawEvent["assignee"] != "" {
+		t.Errorf("expected empty assignee, got %v", got.RawEvent["assignee"])
+	}
+	if got.RawEvent["assignee_username"] != "" {
+		t.Errorf("expected empty assignee_username, got %v", got.RawEvent["assignee_username"])
+	}
+}
+
+func TestGenerateNotificationsFromTemplateAssignedIsUnchanged(t *testing.T) {
+	// The assigned case must keep its existing wording and routing.
+	assignedUser := member(3, true, nModel.NotificationPlatformPushover, "recipient-key")
+	assignedUser.DisplayName = "Alice"
+	assignedUser.Username = "alice"
+
+	notifications := generateNotificationsFromTemplate(choreDueTomorrow(), assignedUser, assignedUser, nil)
+
+	if len(notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifications))
+	}
+	got := notifications[0]
+
+	if got.Text != "📅 Reminder: *Take out trash* is due today and assigned to Alice." {
+		t.Errorf("unexpected assigned text: %q", got.Text)
+	}
+	if got.RawEvent["assignee"] != "Alice" {
+		t.Errorf("expected assignee Alice, got %v", got.RawEvent["assignee"])
+	}
+	if got.RawEvent["assignee_username"] != "alice" {
+		t.Errorf("expected assignee_username alice, got %v", got.RawEvent["assignee_username"])
+	}
+}
+
+func TestGenerateNotificationsFromTemplateOverrideTargetWins(t *testing.T) {
+	// The CircleGroup path overrides the recipient's own target with the group chat ID.
+	assignedUser := member(3, true, nModel.NotificationPlatformTelegram, "personal-chat")
+	groupID := int64(-100123)
+
+	notifications := generateNotificationsFromTemplate(choreDueTomorrow(), assignedUser, assignedUser, &groupID)
+
+	if len(notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifications))
+	}
+	if notifications[0].TargetID != "-100123" {
+		t.Errorf("expected group target -100123, got %q", notifications[0].TargetID)
+	}
+}
+
+func TestGenerateNotificationsFromTemplateFanOutPerMember(t *testing.T) {
+	// End result of the fix: one notification per eligible member, each to their own target.
+	chore := choreDueTomorrow()
+	members := notifiableMembers([]*cModel.UserCircleDetail{
+		member(1, true, nModel.NotificationPlatformPushover, "key-1"),
+		member(2, true, nModel.NotificationPlatformTelegram, "chat-2"),
+		member(3, false, nModel.NotificationPlatformPushover, "key-3"), // pending, excluded
+	})
+
+	notifications := make([]*nModel.Notification, 0)
+	for _, m := range members {
+		notifications = append(notifications, generateNotificationsFromTemplate(chore, m, nil, nil)...)
+	}
+
+	if len(notifications) != 2 {
+		t.Fatalf("expected 2 notifications, got %d", len(notifications))
+	}
+	targets := map[string]bool{}
+	for _, n := range notifications {
+		targets[n.TargetID] = true
+	}
+	for _, want := range []string{"key-1", "chat-2"} {
+		if !targets[want] {
+			t.Errorf("expected a notification targeting %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Send reminders to all circle members for chores assigned to "Anyone" (#721)

The planner only generated notifications when chore.AssignedTo resolved to
a circle member, so unassigned chores produced zero rows on every platform.
Fan out per member instead, excluding pending join requests and members
with no delivery target.