### PR TITLE
Security: Potential SQL Injection via Improper JOIN Condition

### DIFF
--- a/external/user/repo/repository.go
+++ b/external/user/repo/repository.go
@@ -23,7 +23,7 @@ func (a *ExtendedUserRepository) FindFullUserByEmail(ctx context.Context, email 
 	if err := a.db.Table("users").
 		Select("users.*, s.expired_at, s.status , s.customer_id").
 		Joins("LEFT JOIN stripe_customers sc ON sc.user_id = users.id").
-		Joins("LEFT JOIN stripe_subscriptions s ON s.customer_id = sc.customer_id AND s.expired_at > now() OR s.expired_at is null").
+		Joins("LEFT JOIN stripe_subscriptions s ON s.customer_id = sc.customer_id AND (s.expired_at > now() OR s.expired_at is null)").
 		Where("email = ?", email).
 		First(&acc).Error; err != nil {
 		logger.Error("repository.user.FindFullUserByEmail failed to find", "err", err)
@@ -39,7 +39,7 @@ func (a *ExtendedUserRepository) FindFullUserByUsername(ctx context.Context, use
 	if err := a.db.Table("users").
 		Select("users.*, s.expired_at, s.status , s.customer_id").
 		Joins("LEFT JOIN stripe_customers sc ON sc.user_id = users.id").
-		Joins("LEFT JOIN stripe_subscriptions s ON s.customer_id = sc.customer_id AND s.expired_at > now() OR s.expired_at is null").
+		Joins("LEFT JOIN stripe_subscriptions s ON s.customer_id = sc.customer_id AND (s.expired_at > now() OR s.expired_at is null)").
 		Where("username = ?", username).
 		First(&acc).Error; err != nil {
 		logger.Error("repository.user.FindFullUserByUsername failed to find", "err", err)


### PR DESCRIPTION
## Summary

Security: Potential SQL Injection via Improper JOIN Condition

## Problem

**Severity**: `High` | **File**: `external/user/repo/repository.go:L25`

The `Joins` clause for `stripe_subscriptions` uses `s.expired_at > now() OR s.expired_at is null` without proper parentheses. Due to SQL operator precedence, this condition is applied globally to the entire result set rather than just the JOIN condition. This can lead to unintended Cartesian products or data leakage across users, potentially exposing subscription data to the wrong users.

## Solution

Wrap the JOIN condition in parentheses: `Joins("LEFT JOIN stripe_subscriptions s ON s.customer_id = sc.customer_id AND (s.expired_at > now() OR s.expired_at is null)")`.

## Changes

- `external/user/repo/repository.go` (modified)