### PR TITLE
Add private projects visible only to their creator

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -26,6 +26,7 @@ import (
 	nRepo "donetick.com/core/internal/notifier/repo"
 	nps "donetick.com/core/internal/notifier/service"
 	fcmService "donetick.com/core/internal/notifier/service/fcm"
+	pjRepo "donetick.com/core/internal/project/repo"
 	"donetick.com/core/internal/realtime"
 	storage "donetick.com/core/internal/storage"
 	storageModel "donetick.com/core/internal/storage/model"
@@ -58,6 +59,7 @@ type Handler struct {
 	storage         storage.Storage
 	realTimeService *realtime.RealTimeService
 	signer          storage.URLSigner
+	pjRepo          *pjRepo.ProjectRepository
 }
 
 func NewHandler(cr *chRepo.ChoreRepository, circleRepo *cRepo.CircleRepository, nt *notifier.Notifier,
@@ -68,9 +70,11 @@ func NewHandler(cr *chRepo.ChoreRepository, circleRepo *cRepo.CircleRepository, 
 	dr *dRepo.DeviceRepository,
 	stoRepo *storageRepo.StorageRepository,
 	signer storage.URLSigner,
-	rts *realtime.RealTimeService) *Handler {
+	rts *realtime.RealTimeService,
+	projectRepo *pjRepo.ProjectRepository) *Handler {
 	return &Handler{
 		choreRepo:       cr,
+		pjRepo:          projectRepo,
 		uRepo:           ur,
 		deviceRepo:      dr,
 		circleRepo:      circleRepo,
@@ -516,6 +520,12 @@ func (h *Handler) CreateChore(c *gin.Context) {
 	}
 
 	warnings := setCreateChoreDefaults(&choreReq)
+	if err := h.inheritProjectPrivacy(c, &choreReq, currentUser.ID, currentUser.CircleID); err != nil {
+		c.JSON(400, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
 	if !choreReq.Notification && choreReq.NotificationMetadata != nil {
 		warnings = append(warnings, "notificationMetadata provided while notification is false; ignoring metadata")
 		choreReq.NotificationMetadata = nil
@@ -866,6 +876,12 @@ func (h *Handler) EditChore(c *gin.Context) {
 	}
 
 	setEditChoreDefaults(&choreReq, oldChore)
+	if err := h.inheritProjectPrivacy(c, &choreReq, currentUser.ID, currentUser.CircleID); err != nil {
+		c.JSON(400, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
 
 	updatedChore := &chModel.Chore{ // TODO: Assignees are missing
 		ID:                     choreReq.ID,
@@ -1027,6 +1043,28 @@ func setEditChoreDefaults(choreReq *ChoreReq, oldChore *chModel.Chore) {
 	if choreReq.IsPrivate == nil {
 		choreReq.IsPrivate = &oldChore.IsPrivate
 	}
+}
+
+// inheritProjectPrivacy makes sure the project a chore is being placed in is visible
+// to the user, and forces the chore private when that project is private: a chore
+// inherits the privacy of its project, so the project flag always wins. Chores in a
+// public project (or in no project at all) keep their own flag.
+func (h *Handler) inheritProjectPrivacy(c *gin.Context, choreReq *ChoreReq, userID int, circleID int) error {
+	if choreReq.ProjectID == nil {
+		return nil
+	}
+
+	project, err := h.pjRepo.GetProjectByID(c, *choreReq.ProjectID, circleID)
+	// Don't tell apart "missing" from "not visible", it would leak private projects.
+	if err != nil || !project.CanView(userID) {
+		return errors.New("project not found")
+	}
+
+	if project.IsPrivate {
+		isPrivate := true
+		choreReq.IsPrivate = &isPrivate
+	}
+	return nil
 }
 
 func (h *Handler) deleteChoreFiles(ctx *gin.Context, choreID int) {

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -519,13 +519,16 @@ func (h *Handler) CreateChore(c *gin.Context) {
 		dueDate = &utcDate
 	}
 
-	warnings := setCreateChoreDefaults(&choreReq)
+	// Before the defaults, so a chore inheriting privacy from its project isn't warned
+	// about defaulting to public.
 	if err := h.inheritProjectPrivacy(c, &choreReq, currentUser.ID, currentUser.CircleID); err != nil {
 		c.JSON(400, gin.H{
 			"error": err.Error(),
 		})
 		return
 	}
+
+	warnings := setCreateChoreDefaults(&choreReq)
 	if !choreReq.Notification && choreReq.NotificationMetadata != nil {
 		warnings = append(warnings, "notificationMetadata provided while notification is false; ignoring metadata")
 		choreReq.NotificationMetadata = nil
@@ -734,6 +737,14 @@ func (h *Handler) EditChore(c *gin.Context) {
 		return
 	}
 
+	// Before the assignee diff below, so a private project can narrow the list down.
+	if err := h.inheritProjectPrivacy(c, &choreReq, currentUser.ID, currentUser.CircleID); err != nil {
+		c.JSON(400, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
 	var choreAssigneesToAdd []*chModel.ChoreAssignees
 	var choreAssigneesToDelete []*chModel.ChoreAssignees
 
@@ -876,12 +887,6 @@ func (h *Handler) EditChore(c *gin.Context) {
 	}
 
 	setEditChoreDefaults(&choreReq, oldChore)
-	if err := h.inheritProjectPrivacy(c, &choreReq, currentUser.ID, currentUser.CircleID); err != nil {
-		c.JSON(400, gin.H{
-			"error": err.Error(),
-		})
-		return
-	}
 
 	updatedChore := &chModel.Chore{ // TODO: Assignees are missing
 		ID:                     choreReq.ID,
@@ -1049,6 +1054,11 @@ func setEditChoreDefaults(choreReq *ChoreReq, oldChore *chModel.Chore) {
 // to the user, and forces the chore private when that project is private: a chore
 // inherits the privacy of its project, so the project flag always wins. Chores in a
 // public project (or in no project at all) keep their own flag.
+//
+// It also keeps the assignees of such a chore down to the project owner, the only
+// user who can see it: assigning it to anyone else is rejected, and "Anyone" (an
+// empty assignee list) resolves to the owner instead of the whole circle, so the
+// chore never rotates or notifies its way to someone who can't see it.
 func (h *Handler) inheritProjectPrivacy(c *gin.Context, choreReq *ChoreReq, userID int, circleID int) error {
 	if choreReq.ProjectID == nil {
 		return nil
@@ -1060,9 +1070,29 @@ func (h *Handler) inheritProjectPrivacy(c *gin.Context, choreReq *ChoreReq, user
 		return errors.New("project not found")
 	}
 
-	if project.IsPrivate {
-		isPrivate := true
-		choreReq.IsPrivate = &isPrivate
+	if !project.IsPrivate {
+		return nil
+	}
+
+	isPrivate := true
+	choreReq.IsPrivate = &isPrivate
+
+	for _, assignee := range choreReq.Assignees {
+		if assignee.UserID != project.CreatedBy {
+			return errors.New("chores in a private project can only be assigned to its owner")
+		}
+	}
+	if choreReq.AssignedTo != nil && *choreReq.AssignedTo != project.CreatedBy {
+		return errors.New("chores in a private project can only be assigned to its owner")
+	}
+
+	// "Anyone" would otherwise spread over the whole circle when rotating or notifying.
+	if len(choreReq.Assignees) == 0 && choreReq.AssignStrategy != chModel.AssignmentStrategyNoAssignee {
+		choreReq.Assignees = []chModel.ChoreAssignees{{ChoreID: choreReq.ID, UserID: project.CreatedBy}}
+		if choreReq.AssignedTo == nil {
+			owner := project.CreatedBy
+			choreReq.AssignedTo = &owner
+		}
 	}
 	return nil
 }

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -119,8 +119,12 @@ func (r *ChoreRepository) UpdateChoreFields(ctx context.Context, choreID int, fi
 // nextSyncVersionRange atomically reserves a contiguous block of `count` sync
 // versions for a circle and returns the first (lowest) version in the range.
 func (r *ChoreRepository) nextSyncVersionRange(ctx context.Context, circleID int, count int) (int64, error) {
+	return r.nextSyncVersionRangeWithDB(ctx, r.db, circleID, count)
+}
+
+func (r *ChoreRepository) nextSyncVersionRangeWithDB(ctx context.Context, db *gorm.DB, circleID int, count int) (int64, error) {
 	var endVersion int64
-	err := r.db.WithContext(ctx).Raw(`
+	err := db.WithContext(ctx).Raw(`
 		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
 		VALUES (?, ?, ?)
 		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + ?
@@ -128,6 +132,37 @@ func (r *ChoreRepository) nextSyncVersionRange(ctx context.Context, circleID int
 		circleID, syncModel.EntityTypeChore, count, count,
 	).Scan(&endVersion).Error
 	return endVersion - int64(count) + 1, err
+}
+
+// SetProjectChoresPrivacy aligns is_private of every chore in a project with the
+// project's own flag, bumping each chore's sync_version so delta-sync clients pick
+// the change up. It runs on the provided tx (which may be r.db) so callers can keep
+// the project update and this propagation atomic.
+func (r *ChoreRepository) SetProjectChoresPrivacy(ctx context.Context, tx *gorm.DB, circleID int, projectID int, isPrivate bool) error {
+	var choreIDs []int
+	if err := tx.WithContext(ctx).Model(&chModel.Chore{}).
+		Where("project_id = ? AND circle_id = ? AND is_private != ?", projectID, circleID, isPrivate).
+		Pluck("id", &choreIDs).Error; err != nil {
+		return err
+	}
+	if len(choreIDs) == 0 {
+		return nil
+	}
+
+	startVersion, err := r.nextSyncVersionRangeWithDB(ctx, tx, circleID, len(choreIDs))
+	if err != nil {
+		return err
+	}
+
+	for offset, choreID := range choreIDs {
+		if err := tx.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
+			"is_private":   isPrivate,
+			"sync_version": startVersion + int64(offset),
+		}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *ChoreRepository) UpdateChores(c context.Context, chores []*chModel.Chore) error {

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -34,16 +34,33 @@ func NewChoreRepository(db *gorm.DB, cfg *config.Config) *ChoreRepository {
 	return &ChoreRepository{db: db, dbType: cfg.Database.Type}
 }
 
+// privacyJoins adds the joins privacyPredicate depends on: the current user's row in
+// chore_assignees, and the project the chore belongs to (if any).
+//
+// Use as: privacyJoins(db, userID).Where(privacyPredicate(userID))
+func privacyJoins(db *gorm.DB, userID int) *gorm.DB {
+	return db.
+		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
+		Joins("LEFT JOIN projects ON projects.id = chores.project_id")
+}
+
 // privacyPredicate returns a GORM clause expression that enforces chore visibility
-// rules using bound parameters (no string interpolation). A chore is visible if:
+// rules using bound parameters (no string interpolation). A chore in a private
+// project is visible only to the owner of that project — the chore's own privacy
+// flag and its assignees don't widen it, since a user who can't see the project
+// can't see what's inside it either. Everywhere else the chore's own rule applies:
 //   - It is not private, OR
 //   - It is private AND (the user created it OR the user is assigned to it)
 //
-// Use as: db.Where(privacyPredicate(userID))
+// Requires the joins added by privacyJoins.
 func privacyPredicate(userID int) clause.Expr {
 	return clause.Expr{
-		SQL:  `((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))`,
-		Vars: []interface{}{userID, userID},
+		SQL: `(
+			((projects.id IS NULL OR projects.is_private = false)
+				AND ((chores.is_private = false) OR (chores.created_by = ? OR chore_assignees.user_id = ?)))
+			OR (projects.is_private = true AND projects.created_by = ?)
+		)`,
+		Vars: []interface{}{userID, userID, userID},
 	}
 }
 
@@ -134,31 +151,118 @@ func (r *ChoreRepository) nextSyncVersionRangeWithDB(ctx context.Context, db *go
 	return endVersion - int64(count) + 1, err
 }
 
+// projectChore is the subset of a chore SetProjectChoresPrivacy needs to decide what
+// to update.
+type projectChore struct {
+	ID             int
+	IsPrivate      bool
+	AssignedTo     *int
+	AssignStrategy chModel.AssignmentStrategy
+}
+
 // SetProjectChoresPrivacy aligns is_private of every chore in a project with the
 // project's own flag, bumping each chore's sync_version so delta-sync clients pick
 // the change up. It runs on the provided tx (which may be r.db) so callers can keep
 // the project update and this propagation atomic.
-func (r *ChoreRepository) SetProjectChoresPrivacy(ctx context.Context, tx *gorm.DB, circleID int, projectID int, isPrivate bool) error {
-	var choreIDs []int
+//
+// Turning a project private also narrows its chores down to the owner — the only
+// user who can still see them: assignees other than the owner are dropped, chores
+// assigned to "Anyone" are pinned to the owner, and an assigned_to pointing at
+// somebody else is moved over. Otherwise those users would keep getting reminders
+// and rotation turns for chores that vanished from their list.
+func (r *ChoreRepository) SetProjectChoresPrivacy(ctx context.Context, tx *gorm.DB, circleID int, projectID int, ownerID int, isPrivate bool) error {
+	var chores []projectChore
 	if err := tx.WithContext(ctx).Model(&chModel.Chore{}).
-		Where("project_id = ? AND circle_id = ? AND is_private != ?", projectID, circleID, isPrivate).
-		Pluck("id", &choreIDs).Error; err != nil {
+		Select("id, is_private, assigned_to, assign_strategy").
+		Where("project_id = ? AND circle_id = ?", projectID, circleID).
+		Scan(&chores).Error; err != nil {
 		return err
 	}
-	if len(choreIDs) == 0 {
+	if len(chores) == 0 {
 		return nil
 	}
 
-	startVersion, err := r.nextSyncVersionRangeWithDB(ctx, tx, circleID, len(choreIDs))
+	choreIDs := make([]int, 0, len(chores))
+	for _, chore := range chores {
+		choreIDs = append(choreIDs, chore.ID)
+	}
+
+	// Only used when going private, to tell apart chores that need their assignees
+	// trimmed from the ones already down to the owner.
+	foreignAssignees := map[int]bool{}
+	ownerAssigned := map[int]bool{}
+	if isPrivate {
+		var assignees []chModel.ChoreAssignees
+		if err := tx.WithContext(ctx).Where("chore_id IN ?", choreIDs).Find(&assignees).Error; err != nil {
+			return err
+		}
+		for _, assignee := range assignees {
+			if assignee.UserID == ownerID {
+				ownerAssigned[assignee.ChoreID] = true
+			} else {
+				foreignAssignees[assignee.ChoreID] = true
+			}
+		}
+	}
+
+	type choreUpdate struct {
+		chore   projectChore
+		fields  map[string]interface{}
+		addSelf bool
+		dropOld bool
+	}
+	var updates []choreUpdate
+	for _, chore := range chores {
+		update := choreUpdate{chore: chore, fields: map[string]interface{}{}}
+		if chore.IsPrivate != isPrivate {
+			update.fields["is_private"] = isPrivate
+		}
+		if isPrivate {
+			update.dropOld = foreignAssignees[chore.ID]
+			// A chore with no assignee at all means "Anyone", which now resolves to the
+			// owner — unless it is deliberately unassigned.
+			update.addSelf = !ownerAssigned[chore.ID] && chore.AssignStrategy != chModel.AssignmentStrategyNoAssignee
+			if chore.AssignedTo != nil && *chore.AssignedTo != ownerID {
+				if chore.AssignStrategy == chModel.AssignmentStrategyNoAssignee {
+					update.fields["assigned_to"] = nil
+				} else {
+					update.fields["assigned_to"] = ownerID
+				}
+			}
+		}
+		if len(update.fields) == 0 && !update.addSelf && !update.dropOld {
+			continue
+		}
+		updates = append(updates, update)
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+
+	startVersion, err := r.nextSyncVersionRangeWithDB(ctx, tx, circleID, len(updates))
 	if err != nil {
 		return err
 	}
 
-	for offset, choreID := range choreIDs {
-		if err := tx.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(map[string]interface{}{
-			"is_private":   isPrivate,
-			"sync_version": startVersion + int64(offset),
-		}).Error; err != nil {
+	for offset, update := range updates {
+		if update.dropOld {
+			if err := tx.WithContext(ctx).
+				Where("chore_id = ? AND user_id != ?", update.chore.ID, ownerID).
+				Delete(&chModel.ChoreAssignees{}).Error; err != nil {
+				return err
+			}
+		}
+		if update.addSelf {
+			if err := tx.WithContext(ctx).Create(&chModel.ChoreAssignees{
+				ChoreID: update.chore.ID,
+				UserID:  ownerID,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		update.fields["sync_version"] = startVersion + int64(offset)
+		if err := tx.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", update.chore.ID).
+			Updates(update.fields).Error; err != nil {
 			return err
 		}
 	}
@@ -198,13 +302,13 @@ func (r *ChoreRepository) CreateChore(c context.Context, chore *chModel.Chore) (
 
 func (r *ChoreRepository) GetChore(c context.Context, choreID int, userID int, circleID int) (*chModel.Chore, error) {
 	var chore chModel.Chore
-	query := r.db.WithContext(c).Model(&chModel.Chore{}).
+	query := privacyJoins(r.db.WithContext(c).Model(&chModel.Chore{}), userID).
 		Preload("SubTasks", "chore_id = ?", choreID).
 		Preload("Assignees").
 		Preload("ThingChore").
 		Preload("LabelsV2").
-		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
-		Where("chores.id = ? AND chores.circle_id = ? AND ((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))", choreID, circleID, userID, userID)
+		Where("chores.id = ? AND chores.circle_id = ?", choreID, circleID).
+		Where(privacyPredicate(userID))
 
 	if err := query.First(&chore).Error; err != nil {
 		return nil, err
@@ -219,10 +323,9 @@ func (r *ChoreRepository) GetChore(c context.Context, choreID int, userID int, c
 func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int, includeArchived bool, syncOptions *SyncOptions, includeSubtasks bool) ([]*chModel.Chore, error) {
 	var chores []*chModel.Chore
 
-	query := r.db.WithContext(c).
+	query := privacyJoins(r.db.WithContext(c).Model(&chModel.Chore{}), userID).
 		Preload("Assignees").
 		Preload("LabelsV2").
-		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
 		Where("chores.circle_id = ?", circleID).
 		Where(privacyPredicate(userID)).
 		Group("chores.id")
@@ -252,10 +355,9 @@ func (r *ChoreRepository) GetChores(c context.Context, circleID int, userID int,
 
 func (r *ChoreRepository) GetArchivedChores(c context.Context, circleID int, userID int) ([]*chModel.Chore, error) {
 	var chores []*chModel.Chore
-	if err := r.db.WithContext(c).
+	if err := privacyJoins(r.db.WithContext(c).Model(&chModel.Chore{}), userID).
 		Preload("Assignees").
 		Preload("LabelsV2").
-		Joins("left join chore_assignees on chores.id = chore_assignees.chore_id").
 		Where("chores.circle_id = ?", circleID).
 		Where(privacyPredicate(userID)).
 		Where("is_active = ?", false).
@@ -857,8 +959,7 @@ func (r *ChoreRepository) SetDueDateIfNotExisted(c context.Context, choreID int,
 
 func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, circleID int, userID int) (*chModel.ChoreDetail, error) {
 	var choreDetail chModel.ChoreDetail
-	if err := r.db.WithContext(c).
-		Table("chores").
+	if err := privacyJoins(r.db.WithContext(c).Table("chores"), userID).
 		Preload("Subtasks").
 		Select(`
         chores.id, 
@@ -900,8 +1001,8 @@ func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, cir
         AND status IN (1, 2, 3, 4)
     ) AS recent_history ON chores.id = recent_history.chore_id`).
 		Joins("LEFT JOIN time_sessions ON chores.id = time_sessions.chore_id AND time_sessions.status < ?", chModel.TimeSessionStatusCompleted).
-		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
-		Where("chores.id = ? AND chores.circle_id = ? AND ((chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?)))", choreID, circleID, userID, userID).
+		Where("chores.id = ? AND chores.circle_id = ?", choreID, circleID).
+		Where(privacyPredicate(userID)).
 		Group("chores.id, recent_history.last_completed_date, recent_history.last_assigned_to, recent_history.last_completed_by, recent_history.notes, time_sessions.start_time, time_sessions.updated_at").
 		First(&choreDetail).Error; err != nil {
 		return nil, err
@@ -951,8 +1052,9 @@ func (r *ChoreRepository) GetChoresHistoryByUserID(c context.Context, userID int
 		Joins("LEFT JOIN circles ON chores.circle_id = circles.id").
 		Joins("LEFT JOIN time_sessions ON chore_histories.id = time_sessions.chore_history_id").
 		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
+		Joins("LEFT JOIN projects ON projects.id = chores.project_id").
 		Where("circles.id = ? AND chore_histories.updated_at > ?", circleID, since).
-		Where("(chores.is_private = false) OR (chores.is_private = true AND (chores.created_by = ? OR chore_assignees.user_id = ?))", userID, userID).
+		Where(privacyPredicate(userID)).
 		Order("chore_histories.performed_at desc, chore_histories.updated_at desc")
 
 	if !includeCircle {
@@ -1137,6 +1239,7 @@ func (r *ChoreRepository) GetChoresHistoryByCircle(c context.Context, circleID i
 		Joins("JOIN chores ON chores.id = chore_histories.chore_id").
 		Joins("LEFT JOIN time_sessions ON time_sessions.chore_history_id = chore_histories.id").
 		Joins("LEFT JOIN chore_assignees ON chores.id = chore_assignees.chore_id AND chore_assignees.user_id = ?", userID).
+		Joins("LEFT JOIN projects ON projects.id = chores.project_id").
 		Where("chores.circle_id = ?", circleID).
 		Where(privacyPredicate(userID))
 

--- a/internal/chore/repo/repository_test.go
+++ b/internal/chore/repo/repository_test.go
@@ -1,0 +1,214 @@
+package chore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"donetick.com/core/config"
+	chModel "donetick.com/core/internal/chore/model"
+	"donetick.com/core/internal/database"
+	pModel "donetick.com/core/internal/project/model"
+)
+
+const (
+	testCircleID = 1
+	testOwnerID  = 1
+	testOtherID  = 2
+)
+
+func newTestChoreRepo(t *testing.T) (*ChoreRepository, *gorm.DB) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test_chores.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	if err := database.Migration(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.Type = "sqlite"
+	return NewChoreRepository(db, cfg), db
+}
+
+func createProject(t *testing.T, db *gorm.DB, createdBy int, isPrivate bool) *pModel.Project {
+	t.Helper()
+
+	project := &pModel.Project{
+		Name:      "project",
+		CircleID:  testCircleID,
+		CreatedBy: createdBy,
+		IsPrivate: isPrivate,
+	}
+	if err := db.Create(project).Error; err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+	return project
+}
+
+// createChore inserts a chore, optionally inside a project, with the given assignees.
+func createChore(t *testing.T, db *gorm.DB, name string, createdBy int, isPrivate bool, projectID *int, assignees ...int) *chModel.Chore {
+	t.Helper()
+
+	chore := &chModel.Chore{
+		Name:      name,
+		CircleID:  testCircleID,
+		CreatedBy: createdBy,
+		IsPrivate: isPrivate,
+		ProjectID: projectID,
+		IsActive:  true,
+	}
+	if err := db.Create(chore).Error; err != nil {
+		t.Fatalf("failed to create chore %q: %v", name, err)
+	}
+	for _, userID := range assignees {
+		if err := db.Create(&chModel.ChoreAssignees{ChoreID: chore.ID, UserID: userID}).Error; err != nil {
+			t.Fatalf("failed to assign chore %q to %d: %v", name, userID, err)
+		}
+	}
+	return chore
+}
+
+func visibleChoreNames(t *testing.T, r *ChoreRepository, userID int) []string {
+	t.Helper()
+
+	chores, err := r.GetChores(context.Background(), testCircleID, userID, false, nil, false)
+	if err != nil {
+		t.Fatalf("GetChores failed: %v", err)
+	}
+	names := make([]string, 0, len(chores))
+	for _, chore := range chores {
+		names = append(names, chore.Name)
+	}
+	return names
+}
+
+func contains(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// A user who can't see the project can't see its chores either, not even the ones
+// assigned to them: otherwise the API hands out a chore pointing at a project that
+// isn't in the user's project list, and it silently disappears from every view.
+func TestGetChoresHidesChoresInSomeoneElsesPrivateProject(t *testing.T) {
+	r, db := newTestChoreRepo(t)
+
+	project := createProject(t, db, testOtherID, true)
+	createChore(t, db, "assigned-to-me", testOtherID, true, &project.ID, testOwnerID)
+	createChore(t, db, "not-mine", testOtherID, true, &project.ID, testOtherID)
+
+	names := visibleChoreNames(t, r, testOwnerID)
+	if len(names) != 0 {
+		t.Errorf("got %v, want no chore from a private project owned by someone else", names)
+	}
+}
+
+// The flip side: the owner of a private project sees everything in it, including
+// chores somebody else created there while the project was still public.
+func TestGetChoresShowsEveryChoreInOwnPrivateProject(t *testing.T) {
+	r, db := newTestChoreRepo(t)
+
+	project := createProject(t, db, testOwnerID, true)
+	createChore(t, db, "created-by-other", testOtherID, true, &project.ID, testOtherID)
+	createChore(t, db, "created-by-me", testOwnerID, true, &project.ID, testOwnerID)
+
+	names := visibleChoreNames(t, r, testOwnerID)
+	if !contains(names, "created-by-other") || !contains(names, "created-by-me") {
+		t.Errorf("got %v, want both chores of the user's own private project", names)
+	}
+}
+
+// Chore-level privacy keeps working as before outside private projects.
+func TestGetChoresKeepsChoreLevelPrivacyOutsidePrivateProjects(t *testing.T) {
+	r, db := newTestChoreRepo(t)
+
+	publicProject := createProject(t, db, testOtherID, false)
+	createChore(t, db, "public-no-project", testOtherID, false, nil)
+	createChore(t, db, "public-in-project", testOtherID, false, &publicProject.ID)
+	createChore(t, db, "private-assigned", testOtherID, true, &publicProject.ID, testOwnerID)
+	createChore(t, db, "private-theirs", testOtherID, true, &publicProject.ID, testOtherID)
+
+	names := visibleChoreNames(t, r, testOwnerID)
+	for _, want := range []string{"public-no-project", "public-in-project", "private-assigned"} {
+		if !contains(names, want) {
+			t.Errorf("got %v, want it to contain %q", names, want)
+		}
+	}
+	if contains(names, "private-theirs") {
+		t.Errorf("got %v, want it to hide a private chore of another user", names)
+	}
+}
+
+func TestGetChoreAppliesProjectPrivacy(t *testing.T) {
+	r, db := newTestChoreRepo(t)
+	ctx := context.Background()
+
+	project := createProject(t, db, testOtherID, true)
+	chore := createChore(t, db, "theirs", testOtherID, true, &project.ID, testOwnerID)
+
+	if _, err := r.GetChore(ctx, chore.ID, testOwnerID, testCircleID); err == nil {
+		t.Error("GetChore should not return a chore from someone else's private project")
+	}
+	if _, err := r.GetChore(ctx, chore.ID, testOtherID, testCircleID); err != nil {
+		t.Errorf("GetChore failed for the project owner: %v", err)
+	}
+}
+
+func TestSetProjectChoresPrivacyNarrowsAssigneesToOwner(t *testing.T) {
+	r, db := newTestChoreRepo(t)
+	ctx := context.Background()
+
+	project := createProject(t, db, testOwnerID, false)
+	shared := createChore(t, db, "shared", testOwnerID, false, &project.ID, testOwnerID, testOtherID)
+	anyone := createChore(t, db, "anyone", testOwnerID, false, &project.ID)
+	if err := db.Model(&chModel.Chore{}).Where("id = ?", shared.ID).Update("assigned_to", testOtherID).Error; err != nil {
+		t.Fatalf("failed to set assigned_to: %v", err)
+	}
+
+	if err := r.SetProjectChoresPrivacy(ctx, db, testCircleID, project.ID, testOwnerID, true); err != nil {
+		t.Fatalf("SetProjectChoresPrivacy failed: %v", err)
+	}
+
+	assertAssignees(t, db, shared.ID, []int{testOwnerID})
+	assertAssignees(t, db, anyone.ID, []int{testOwnerID})
+
+	var updated chModel.Chore
+	if err := db.First(&updated, shared.ID).Error; err != nil {
+		t.Fatalf("failed to reload chore: %v", err)
+	}
+	if updated.AssignedTo == nil || *updated.AssignedTo != testOwnerID {
+		t.Errorf("assigned_to = %v, want the project owner", updated.AssignedTo)
+	}
+}
+
+func assertAssignees(t *testing.T, db *gorm.DB, choreID int, want []int) {
+	t.Helper()
+
+	var assignees []chModel.ChoreAssignees
+	if err := db.Where("chore_id = ?", choreID).Order("user_id asc").Find(&assignees).Error; err != nil {
+		t.Fatalf("failed to load assignees: %v", err)
+	}
+	got := make([]int, 0, len(assignees))
+	for _, assignee := range assignees {
+		got = append(got, assignee.UserID)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("assignees of chore %d = %v, want %v", choreID, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("assignees of chore %d = %v, want %v", choreID, got, want)
+		}
+	}
+}

--- a/internal/notifier/service/planner.go
+++ b/internal/notifier/service/planner.go
@@ -58,7 +58,7 @@ func (n *NotificationPlanner) GenerateNotifications(c context.Context, chore *ch
 			// A chore assigned to "Anyone" has no assigned user to resolve, which previously
 			// meant no notifications were generated at all. Remind every circle member who
 			// can actually receive one instead.
-			for _, member := range notifiableMembers(circleMembers) {
+			for _, member := range anyoneChoreRecipients(chore, circleMembers) {
 				notifications = append(notifications, generateNotificationsFromTemplate(chore, member, nil, nil)...)
 			}
 		}
@@ -89,6 +89,23 @@ func notifiableMembers(circleMembers []*cModel.UserCircleDetail) []*cModel.UserC
 		members = append(members, member)
 	}
 	return members
+}
+
+// anyoneChoreRecipients returns the circle members to remind about a chore assigned to
+// "Anyone": those that can actually receive a notification and are allowed to see the
+// chore. Without the visibility check a private chore with no assignee would leak its
+// name to the whole circle, which project-level privacy makes easy to hit (every chore
+// in a private project is private).
+func anyoneChoreRecipients(chore *chModel.Chore, circleMembers []*cModel.UserCircleDetail) []*cModel.UserCircleDetail {
+	members := notifiableMembers(circleMembers)
+	recipients := make([]*cModel.UserCircleDetail, 0, len(members))
+	for _, member := range members {
+		if !chore.CanView(member.UserID, circleMembers) {
+			continue
+		}
+		recipients = append(recipients, member)
+	}
+	return recipients
 }
 
 func getEventTypeFromTemplate(template *chModel.NotificationTemplate) EventType {

--- a/internal/notifier/service/planner_test.go
+++ b/internal/notifier/service/planner_test.go
@@ -168,3 +168,43 @@ func TestGenerateNotificationsFromTemplateFanOutPerMember(t *testing.T) {
 		}
 	}
 }
+
+func TestAnyoneChoreRecipientsSkipsMembersWhoCannotSeeAPrivateChore(t *testing.T) {
+	// An "Anyone" chore fans out to the whole circle, so a private one (every chore in a
+	// private project is private) must not reach members that can't see it.
+	circleMembers := []*cModel.UserCircleDetail{
+		member(1, true, nModel.NotificationPlatformPushover, "key-1"),
+		member(2, true, nModel.NotificationPlatformTelegram, "chat-2"),
+		member(3, true, nModel.NotificationPlatformPushover, "key-3"),
+	}
+
+	chore := choreDueTomorrow()
+	chore.CreatedBy = 1
+	chore.IsPrivate = true
+	chore.Assignees = []chModel.ChoreAssignees{{ChoreID: chore.ID, UserID: 2}}
+
+	got := anyoneChoreRecipients(chore, circleMembers)
+
+	recipients := map[int]bool{}
+	for _, r := range got {
+		recipients[r.UserID] = true
+	}
+	if len(got) != 2 || !recipients[1] || !recipients[2] {
+		t.Errorf("got recipients %v, want the creator (1) and the assignee (2) only", recipients)
+	}
+}
+
+func TestAnyoneChoreRecipientsKeepsWholeCircleForPublicChores(t *testing.T) {
+	circleMembers := []*cModel.UserCircleDetail{
+		member(1, true, nModel.NotificationPlatformPushover, "key-1"),
+		member(2, true, nModel.NotificationPlatformTelegram, "chat-2"),
+		member(3, false, nModel.NotificationPlatformPushover, "key-3"), // pending, excluded
+	}
+
+	chore := choreDueTomorrow()
+	chore.CreatedBy = 1
+
+	if got := anyoneChoreRecipients(chore, circleMembers); len(got) != 2 {
+		t.Errorf("expected 2 recipients for a public chore, got %d", len(got))
+	}
+}

--- a/internal/project/handler.go
+++ b/internal/project/handler.go
@@ -41,7 +41,7 @@ func (h *Handler) getProjects(c *gin.Context) {
 		return
 	}
 
-	projects, err := h.pRepo.GetCircleProjects(c, currentUser.CircleID)
+	projects, err := h.pRepo.GetCircleProjects(c, currentUser.CircleID, currentUser.ID)
 	if err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error getting projects",
@@ -91,6 +91,7 @@ func (h *Handler) createProject(c *gin.Context) {
 		CircleID:    currentUser.CircleID,
 		CreatedBy:   currentUser.ID,
 		Icon:        req.Icon,
+		IsPrivate:   req.IsPrivate != nil && *req.IsPrivate,
 	}
 
 	if err := h.pRepo.CreateProject(c, project); err != nil {
@@ -154,7 +155,7 @@ func (h *Handler) updateProject(c *gin.Context) {
 		Icon:        req.Icon,
 	}
 
-	if err := h.pRepo.UpdateProject(c, project, currentUser.ID, currentUser.CircleID); err != nil {
+	if err := h.pRepo.UpdateProject(c, project, req.IsPrivate, currentUser.ID, currentUser.CircleID); err != nil {
 		c.JSON(500, gin.H{
 			"error": err.Error(),
 		})

--- a/internal/project/model/model.go
+++ b/internal/project/model/model.go
@@ -13,6 +13,14 @@ type Project struct {
 	CreatedAt   time.Time  `json:"createdAt" gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt   *time.Time `json:"updatedAt,omitempty" gorm:"column:updated_at;autoUpdateTime"`
 	IsDefault   bool       `json:"isDefault" gorm:"column:is_default;default:false"`
+	IsPrivate   bool       `json:"isPrivate" gorm:"column:is_private;default:false"` // Whether the project is only visible to its creator
+}
+
+// CanView reports whether the user is allowed to see the project. Public projects
+// are visible to every member of the circle, private ones only to their creator.
+// Circle admins and managers do not bypass this, same as private chores today.
+func (p *Project) CanView(userID int) bool {
+	return !p.IsPrivate || p.CreatedBy == userID
 }
 
 type ProjectReq struct {
@@ -20,6 +28,9 @@ type ProjectReq struct {
 	Description *string `json:"description"`
 	Color       *string `json:"color"`
 	Icon        *string `json:"icon"`
+	// IsPrivate is optional: when omitted on update the current value is kept, so
+	// older clients that don't know about the field can't accidentally unset it.
+	IsPrivate *bool `json:"isPrivate"`
 }
 
 type UpdateProjectReq struct {

--- a/internal/project/model/model_test.go
+++ b/internal/project/model/model_test.go
@@ -1,0 +1,42 @@
+package model
+
+import "testing"
+
+func TestProjectCanView(t *testing.T) {
+	const owner = 1
+	const otherMember = 2
+
+	tests := []struct {
+		name    string
+		project Project
+		userID  int
+		canView bool
+	}{
+		{
+			name:    "public project is visible to any circle member",
+			project: Project{CreatedBy: owner, IsPrivate: false},
+			userID:  otherMember,
+			canView: true,
+		},
+		{
+			name:    "private project is visible to its creator",
+			project: Project{CreatedBy: owner, IsPrivate: true},
+			userID:  owner,
+			canView: true,
+		},
+		{
+			name:    "private project is hidden from other circle members",
+			project: Project{CreatedBy: owner, IsPrivate: true},
+			userID:  otherMember,
+			canView: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.project.CanView(tt.userID); got != tt.canView {
+				t.Errorf("CanView(%d) = %v, want %v", tt.userID, got, tt.canView)
+			}
+		})
+	}
+}

--- a/internal/project/repo/repository.go
+++ b/internal/project/repo/repository.go
@@ -90,7 +90,7 @@ func (r *ProjectRepository) UpdateProject(ctx context.Context, project *pModel.P
 			return nil
 		}
 
-		if err := r.choreRepo.SetProjectChoresPrivacy(ctx, tx, circleID, project.ID, *isPrivate); err != nil {
+		if err := r.choreRepo.SetProjectChoresPrivacy(ctx, tx, circleID, project.ID, existingProject.CreatedBy, *isPrivate); err != nil {
 			log.Error("Error propagating project privacy to chores", "error", err, "projectID", project.ID)
 			return err
 		}

--- a/internal/project/repo/repository.go
+++ b/internal/project/repo/repository.go
@@ -5,22 +5,28 @@ import (
 	"errors"
 
 	config "donetick.com/core/config"
+	chRepo "donetick.com/core/internal/chore/repo"
 	pModel "donetick.com/core/internal/project/model"
 	"donetick.com/core/logging"
 	"gorm.io/gorm"
 )
 
 type ProjectRepository struct {
-	db *gorm.DB
+	db        *gorm.DB
+	choreRepo *chRepo.ChoreRepository
 }
 
-func NewProjectRepository(db *gorm.DB, cfg *config.Config) *ProjectRepository {
-	return &ProjectRepository{db: db}
+func NewProjectRepository(db *gorm.DB, cfg *config.Config, choreRepo *chRepo.ChoreRepository) *ProjectRepository {
+	return &ProjectRepository{db: db, choreRepo: choreRepo}
 }
 
-func (r *ProjectRepository) GetCircleProjects(ctx context.Context, circleID int) ([]*pModel.Project, error) {
+// GetCircleProjects returns the projects of a circle the user is allowed to see:
+// every public one plus the private ones they created.
+func (r *ProjectRepository) GetCircleProjects(ctx context.Context, circleID int, userID int) ([]*pModel.Project, error) {
 	var projects []*pModel.Project
-	if err := r.db.WithContext(ctx).Where("circle_id = ?", circleID).Order("name ASC").Find(&projects).Error; err != nil {
+	if err := r.db.WithContext(ctx).
+		Where("circle_id = ? AND (is_private = ? OR created_by = ?)", circleID, false, userID).
+		Order("name ASC").Find(&projects).Error; err != nil {
 		return nil, err
 	}
 	return projects, nil
@@ -41,7 +47,10 @@ func (r *ProjectRepository) CreateProject(ctx context.Context, project *pModel.P
 	return nil
 }
 
-func (r *ProjectRepository) UpdateProject(ctx context.Context, project *pModel.Project, userID int, circleID int) error {
+// UpdateProject updates a project owned by the user. isPrivate is optional: when
+// nil the current visibility is kept. Flipping it propagates to every chore in the
+// project, since a chore inherits the privacy of the project it belongs to.
+func (r *ProjectRepository) UpdateProject(ctx context.Context, project *pModel.Project, isPrivate *bool, userID int, circleID int) error {
 	log := logging.FromContext(ctx)
 
 	// Check if user has permission to update this project
@@ -59,17 +68,34 @@ func (r *ProjectRepository) UpdateProject(ctx context.Context, project *pModel.P
 		return errors.New("user does not have permission to update this project")
 	}
 
+	if isPrivate == nil {
+		isPrivate = &existingProject.IsPrivate
+	}
+
 	updates := map[string]interface{}{
 		"name":        project.Name,
 		"description": project.Description,
 		"color":       project.Color,
 		"icon":        project.Icon,
+		"is_private":  *isPrivate,
 	}
 
-	if err := r.db.WithContext(ctx).Model(&pModel.Project{}).Where("id = ? AND circle_id = ?", project.ID, circleID).Updates(updates).Error; err != nil {
-		return err
-	}
-	return nil
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&pModel.Project{}).Where("id = ? AND circle_id = ?", project.ID, circleID).Updates(updates).Error; err != nil {
+			log.Error("Error updating project", "error", err)
+			return err
+		}
+
+		if existingProject.IsPrivate == *isPrivate {
+			return nil
+		}
+
+		if err := r.choreRepo.SetProjectChoresPrivacy(ctx, tx, circleID, project.ID, *isPrivate); err != nil {
+			log.Error("Error propagating project privacy to chores", "error", err, "projectID", project.ID)
+			return err
+		}
+		return nil
+	})
 }
 
 func (r *ProjectRepository) DeleteProject(ctx context.Context, projectID int, userID int, circleID int) error {

--- a/internal/project/repo/repository_test.go
+++ b/internal/project/repo/repository_test.go
@@ -1,0 +1,154 @@
+package repo
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"donetick.com/core/config"
+	chModel "donetick.com/core/internal/chore/model"
+	chRepo "donetick.com/core/internal/chore/repo"
+	"donetick.com/core/internal/database"
+	pModel "donetick.com/core/internal/project/model"
+)
+
+const (
+	testCircleID = 1
+	testOwnerID  = 1
+	testOtherID  = 2
+)
+
+func newTestRepo(t *testing.T) (*ProjectRepository, *gorm.DB) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test_projects.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	if err := database.Migration(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.Type = "sqlite"
+	return NewProjectRepository(db, cfg, chRepo.NewChoreRepository(db, cfg)), db
+}
+
+func createTestProject(t *testing.T, db *gorm.DB, name string, createdBy int, isPrivate bool) *pModel.Project {
+	t.Helper()
+
+	project := &pModel.Project{
+		Name:      name,
+		CircleID:  testCircleID,
+		CreatedBy: createdBy,
+		IsPrivate: isPrivate,
+	}
+	if err := db.Create(project).Error; err != nil {
+		t.Fatalf("failed to create project %q: %v", name, err)
+	}
+	return project
+}
+
+func createTestChore(t *testing.T, db *gorm.DB, projectID int, isPrivate bool) *chModel.Chore {
+	t.Helper()
+
+	chore := &chModel.Chore{
+		Name:      "chore",
+		CircleID:  testCircleID,
+		CreatedBy: testOwnerID,
+		ProjectID: &projectID,
+		IsPrivate: isPrivate,
+	}
+	if err := db.Create(chore).Error; err != nil {
+		t.Fatalf("failed to create chore: %v", err)
+	}
+	return chore
+}
+
+func reloadChore(t *testing.T, db *gorm.DB, choreID int) *chModel.Chore {
+	t.Helper()
+
+	var chore chModel.Chore
+	if err := db.First(&chore, choreID).Error; err != nil {
+		t.Fatalf("failed to reload chore %d: %v", choreID, err)
+	}
+	return &chore
+}
+
+func TestGetCircleProjectsHidesOtherUsersPrivateProjects(t *testing.T) {
+	r, db := newTestRepo(t)
+
+	createTestProject(t, db, "shared", testOwnerID, false)
+	createTestProject(t, db, "mine", testOwnerID, true)
+	createTestProject(t, db, "theirs", testOtherID, true)
+
+	projects, err := r.GetCircleProjects(context.Background(), testCircleID, testOwnerID)
+	if err != nil {
+		t.Fatalf("GetCircleProjects failed: %v", err)
+	}
+
+	names := make([]string, 0, len(projects))
+	for _, p := range projects {
+		names = append(names, p.Name)
+	}
+	if len(names) != 2 || names[0] != "mine" || names[1] != "shared" {
+		t.Errorf("got projects %v, want [mine shared]", names)
+	}
+}
+
+func TestUpdateProjectPropagatesPrivacyToChores(t *testing.T) {
+	r, db := newTestRepo(t)
+	ctx := context.Background()
+
+	project := createTestProject(t, db, "mine", testOwnerID, false)
+	publicChore := createTestChore(t, db, project.ID, false)
+	privateChore := createTestChore(t, db, project.ID, true)
+	versionBefore := reloadChore(t, db, publicChore.ID).SyncVersion
+
+	isPrivate := true
+	if err := r.UpdateProject(ctx, &pModel.Project{ID: project.ID, Name: project.Name}, &isPrivate, testOwnerID, testCircleID); err != nil {
+		t.Fatalf("UpdateProject failed: %v", err)
+	}
+
+	if updated := reloadChore(t, db, publicChore.ID); !updated.IsPrivate {
+		t.Error("chore in a private project should have been made private")
+	} else if updated.SyncVersion <= versionBefore {
+		t.Errorf("sync_version = %d, want > %d so delta sync clients see the change", updated.SyncVersion, versionBefore)
+	}
+
+	// Turning the project public again syncs its chores back, the project wins over
+	// the chore's own flag in both directions.
+	isPrivate = false
+	if err := r.UpdateProject(ctx, &pModel.Project{ID: project.ID, Name: project.Name}, &isPrivate, testOwnerID, testCircleID); err != nil {
+		t.Fatalf("UpdateProject failed: %v", err)
+	}
+	if updated := reloadChore(t, db, privateChore.ID); updated.IsPrivate {
+		t.Error("chore should have been made public with its project")
+	}
+}
+
+func TestUpdateProjectKeepsPrivacyWhenFlagOmitted(t *testing.T) {
+	r, db := newTestRepo(t)
+
+	project := createTestProject(t, db, "mine", testOwnerID, true)
+	chore := createTestChore(t, db, project.ID, true)
+
+	if err := r.UpdateProject(context.Background(), &pModel.Project{ID: project.ID, Name: "renamed"}, nil, testOwnerID, testCircleID); err != nil {
+		t.Fatalf("UpdateProject failed: %v", err)
+	}
+
+	updatedProject, err := r.GetProjectByID(context.Background(), project.ID, testCircleID)
+	if err != nil {
+		t.Fatalf("GetProjectByID failed: %v", err)
+	}
+	if !updatedProject.IsPrivate {
+		t.Error("omitting isPrivate should keep the project private")
+	}
+	if updated := reloadChore(t, db, chore.ID); !updated.IsPrivate {
+		t.Error("chores should be untouched when the project flag doesn't change")
+	}
+}


### PR DESCRIPTION
Implements the project-level privacy discussed in
[discussion #718](https://github.com/donetick/donetick/discussions/718),
following the design you settled on in the thread.

## Behaviour

- `Project.IsPrivate` (default `false`) — private projects are only listed for
  their creator. Circle admins/managers do **not** bypass it, same as private
  chores today.
- **Chores inherit the project's privacy.** Creating or editing a chore inside a
  private project forces `is_private = true`, regardless of what the client
  sends. Chores in a public project (or in no project) keep their own flag, so
  today's per-task privacy is unchanged.
- **Flipping the project flag propagates to its chores**, in both directions:
  the project always wins. Each updated chore gets a fresh `sync_version` so
  delta-sync clients actually see the change (a plain `UPDATE` would have left
  offline clients stale).
- Placing a chore in a project the user can't see is rejected with
  `project not found` — the same error as a missing project, so private projects
  can't be enumerated.
- `isPrivate` is optional on `PUT /projects/{id}`: when omitted the current value
  is kept, so older clients can't unset it by accident.

## Migration

None needed — `AutoMigrate` adds the column with `DEFAULT false`, so existing
projects and installs keep their current visibility until someone opts in.

## Tests

- `Project.CanView` unit tests.
- sqlite integration tests for the list filtering, the propagation in both
  directions (including the `sync_version` bump) and the omitted-flag case.

## Also fixed here

A chore assigned to "Anyone" fans its reminders out to every circle member, and
that path never checked visibility — a private chore with no assignee sent its
name to the whole circle. It was reachable before this PR (only by marking such a
chore private through the API), but every chore in a private project is private,
so project privacy makes it easy to hit from the UI. Recipients now go through
`Chore.CanView`, covered by two tests in `planner_test.go`.

## Not in this PR

- **Frontend.** The privacy toggle on the project form, and disabling the task's
  own toggle with an "inherited from project" hint, live in
  donetick/frontend#169 — that PR needs this one to land first.
- `project_members` (sharing a private project with selected members) is
  deliberately left out: with chores inheriting privacy, a member who isn't an
  assignee still wouldn't see the tasks, so it would need the chore read path to
  change too. It can be added later on top of this without a breaking change.
Two pre-existing gaps I left alone, both of which affect private chores today and
are orthogonal to this change — happy to take either as a follow-up:

- A chore that becomes private is filtered out of other users' delta sync rather
  than tombstoned, so clients that already cached it keep a stale copy until a
  full refresh.
- `EventBroadcaster` sends chore events to every connection in the circle
  (`BroadcastToCircle`) with no visibility check, so a private chore's name
  reaches the whole circle over websockets. The connection pool already indexes
  by user, so this is fixable, but it touches ~15 broadcast call sites and isn't
  specific to project privacy.
