### PR TITLE
docs: add Related Projects section to README (starting with betidy-export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ golangci-lint run --fix
 
 ---
 
+## Related Projects
+
+Community-built tools that work with Donetick:
+
+- **[betidy-export](https://github.com/mschabhuettl/betidy-export)** — export your tasks from the [BeTidy](https://betidy.io) chores app and import them into Donetick, preserving recurrence, due dates, assignees, labels, priority and points.
+
+---
+
 ## License
 
 This project is licensed under the **AGPLv3**. See the [LICENSE](LICENSE.md) file for more details.


### PR DESCRIPTION
### What

Adds a small **Related Projects** section to the README, listing community-built tools that work with Donetick — starting with one entry:

- **[betidy-export](https://github.com/mschabhuettl/betidy-export)** — a BeTidy → Donetick importer (recurrence, due dates, assignees, labels, priority, points).

### Why

A short related-projects section helps users discover community integrations and importers, and gives third-party contributions a place to be referenced.

### Process

Raised first in discussion #754 as suggested by the CONTRIBUTING note. Related: #264 (first-party "import from other apps") and #753 (API notes from building the tool).

Opening as a **draft** — README only, no code changes. Happy to adjust the wording/placement or hold until a maintainer confirms in #754 whether such a section is welcome. 🙌
