### PR TITLE
Expose projects via external API

### DIFF
--- a/internal/chore/api.go
+++ b/internal/chore/api.go
@@ -11,6 +11,7 @@ import (
 	"donetick.com/core/internal/events"
 	nRepo "donetick.com/core/internal/notifier/repo"
 	nps "donetick.com/core/internal/notifier/service"
+	pRepo "donetick.com/core/internal/project/repo"
 	"donetick.com/core/internal/utils"
 	"donetick.com/core/logging"
 	jwt "github.com/appleboy/gin-jwt/v2"
@@ -32,9 +33,10 @@ type API struct {
 	nRepo         *nRepo.NotificationRepository
 	eventProducer *events.EventsProducer
 	stRepo        *stRepo.SubTasksRepository
+	projectRepo   *pRepo.ProjectRepository
 }
 
-func NewAPI(cr *chRepo.ChoreRepository, userRepo *uRepo.UserRepository, circleRepo *cRepo.CircleRepository, nPlanner *nps.NotificationPlanner, nr *nRepo.NotificationRepository, eventProducer *events.EventsProducer, stRepo *stRepo.SubTasksRepository) *API {
+func NewAPI(cr *chRepo.ChoreRepository, userRepo *uRepo.UserRepository, circleRepo *cRepo.CircleRepository, nPlanner *nps.NotificationPlanner, nr *nRepo.NotificationRepository, eventProducer *events.EventsProducer, stRepo *stRepo.SubTasksRepository, projectRepo *pRepo.ProjectRepository) *API {
 	return &API{
 		choreRepo:     cr,
 		userRepo:      userRepo,
@@ -43,6 +45,7 @@ func NewAPI(cr *chRepo.ChoreRepository, userRepo *uRepo.UserRepository, circleRe
 		nRepo:         nr,
 		eventProducer: eventProducer,
 		stRepo:        stRepo,
+		projectRepo:   projectRepo,
 	}
 }
 
@@ -125,6 +128,12 @@ func (h *API) CreateChore(c *gin.Context) {
 			return
 		}
 	}
+	if choreRequest.ProjectID != nil {
+		if _, err := h.projectRepo.GetProjectByID(c, *choreRequest.ProjectID, user.CircleID); err != nil {
+			c.JSON(400, gin.H{"error": "Specified project not found in circle"})
+			return
+		}
+	}
 
 	chore := &chModel.Chore{
 		CreatedBy:     createdBy,
@@ -137,6 +146,7 @@ func (h *API) CreateChore(c *gin.Context) {
 		AssignedTo:     &createdBy,
 		Assignees:      []chModel.ChoreAssignees{{UserID: createdBy}},
 		Description:    choreRequest.Description,
+		ProjectID:      choreRequest.ProjectID,
 		NextDueDate:    nextDueDate,
 		CreatedAt:      time.Now().UTC(),
 	}

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -206,6 +206,7 @@ type ChoreLiteReq struct { // TODO: Remove this when api is removed.
 	ID          int     `json:"id"`
 	DueDate     string  `json:"dueDate"`
 	CreatedBy   *int    `json:"createdBy,omitempty"`
+	ProjectID   *int    `json:"projectId,omitempty"`
 }
 
 func (c *Chore) CanDeleteHistory(

--- a/internal/project/handler.go
+++ b/internal/project/handler.go
@@ -6,6 +6,7 @@ import (
 	"donetick.com/core/internal/auth"
 	pModel "donetick.com/core/internal/project/model"
 	pRepo "donetick.com/core/internal/project/repo"
+	uRepo "donetick.com/core/internal/user/repo"
 	"github.com/gin-gonic/gin"
 )
 
@@ -227,4 +228,11 @@ func Routes(r *gin.Engine, h *Handler, multiAuthMiddleware *auth.MultiAuthMiddle
 		projectRoutes.PUT("/:id", h.updateProject)
 		projectRoutes.DELETE("/:id", h.deleteProject)
 	}
+}
+
+// ExternalAPI exposes the project list to long-lived integrations using an API token.
+func ExternalAPI(r *gin.Engine, h *Handler, userRepo *uRepo.UserRepository) {
+	projectRoutes := r.Group("eapi/v1/project")
+	projectRoutes.Use(auth.APITokenMiddleware(userRepo))
+	projectRoutes.GET("", h.getProjects)
 }

--- a/main.go
+++ b/main.go
@@ -203,6 +203,7 @@ func main() {
 			thing.APIs,
 			label.Routes,
 			project.Routes,
+			project.ExternalAPI,
 			filter.Routes,
 
 			storage.Routes,


### PR DESCRIPTION
 ## Summary

  Expose Projects to long-lived external API integrations.

  ## Changes

  - Add `GET /eapi/v1/project` authenticated by an external API token.
  - Add optional `projectId` to external chore creation.
  - Validate that the requested project belongs to the authenticated user's Circle.
  - Persist the selected project on the created chore.

  ## Motivation

  The external API could create chores but provided no way to discover or assign Projects.

  ## Compatibility

  - Existing requests remain valid.
  - Omitting `projectId` preserves current behavior.
  - No database migration is required.

  ## Validation

  - `go test ./internal/project`
  - `go test ./internal/chore -run '^$' -count=0`
  - `gofmt`