### PR TITLE
Implement user-scoped tombstones for chore visibility changes and enh…

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -716,17 +716,6 @@ func (h *Handler) EditChore(c *gin.Context) {
 		return
 	}
 
-	existedChoreAssignees, err := h.choreRepo.GetChoreAssignees(c, choreReq.ID)
-	if err != nil {
-		c.JSON(500, gin.H{
-			"error": "Error getting chore assignees",
-		})
-		return
-	}
-
-	var choreAssigneesToAdd []*chModel.ChoreAssignees
-	var choreAssigneesToDelete []*chModel.ChoreAssignees
-
 	//  filter assignees that not in the circle
 	for _, assignee := range choreReq.Assignees {
 		userFound := false
@@ -741,33 +730,6 @@ func (h *Handler) EditChore(c *gin.Context) {
 				"error": "Assignee not found in circle",
 			})
 			return
-		}
-		userAlreadyAssignee := false
-		for _, existedChoreAssignee := range existedChoreAssignees {
-			if existedChoreAssignee.UserID == assignee.UserID {
-				userAlreadyAssignee = true
-				break
-			}
-		}
-		if !userAlreadyAssignee {
-			choreAssigneesToAdd = append(choreAssigneesToAdd, &chModel.ChoreAssignees{
-				ChoreID: choreReq.ID,
-				UserID:  assignee.UserID,
-			})
-		}
-	}
-
-	//  remove assignees if they are not in the assignees list anymore
-	for _, existedChoreAssignee := range existedChoreAssignees {
-		userFound := false
-		for _, assignee := range choreReq.Assignees {
-			if existedChoreAssignee.UserID == assignee.UserID {
-				userFound = true
-				break
-			}
-		}
-		if !userFound {
-			choreAssigneesToDelete = append(choreAssigneesToDelete, existedChoreAssignee)
 		}
 	}
 
@@ -893,7 +855,11 @@ func (h *Handler) EditChore(c *gin.Context) {
 		Status:                 oldChore.Status,
 	}
 
-	if err := h.choreRepo.UpsertChore(c, updatedChore); err != nil {
+	assigneeIDs := make([]int, 0, len(choreReq.Assignees))
+	for _, assignee := range choreReq.Assignees {
+		assigneeIDs = append(assigneeIDs, assignee.UserID)
+	}
+	if err := h.choreRepo.UpdateChoreVisibility(c, updatedChore, assigneeIDs); err != nil {
 		c.JSON(500, gin.H{
 			"error": "Error adding chore",
 		})
@@ -947,25 +913,6 @@ func (h *Handler) EditChore(c *gin.Context) {
 		}
 	}
 
-	if len(choreAssigneesToAdd) > 0 {
-		err = h.choreRepo.UpdateChoreAssignees(c, choreAssigneesToAdd)
-
-		if err != nil {
-			c.JSON(500, gin.H{
-				"error": "Error updating chore assignees",
-			})
-			return
-		}
-	}
-	if len(choreAssigneesToDelete) > 0 {
-		err = h.choreRepo.DeleteChoreAssignees(c, choreAssigneesToDelete)
-		if err != nil {
-			c.JSON(500, gin.H{
-				"error": "Error deleting chore assignees",
-			})
-			return
-		}
-	}
 	if oldChore.NextDueDate != updatedChore.NextDueDate {
 		historyEntry := &chModel.ChoreHistory{
 			ChoreID:     oldChore.ID,

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	config "donetick.com/core/config"
@@ -63,6 +64,20 @@ func (r *ChoreRepository) nextSyncVersion(ctx context.Context, circleID int) (in
 	return r.nextSyncVersionWithDB(ctx, r.db, circleID)
 }
 
+// nextSyncVersionRangeWithDB atomically reserves count contiguous sync versions
+// and returns the first (lowest) version in the range.
+func (r *ChoreRepository) nextSyncVersionRangeWithDB(ctx context.Context, db *gorm.DB, circleID int, count int) (int64, error) {
+	var endVersion int64
+	err := db.WithContext(ctx).Raw(`
+		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
+		VALUES (?, ?, ?)
+		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + ?
+		RETURNING max_version`,
+		circleID, syncModel.EntityTypeChore, count, count,
+	).Scan(&endVersion).Error
+	return endVersion - int64(count) + 1, err
+}
+
 func (r *ChoreRepository) insertTombstone(ctx context.Context, tx *gorm.DB, circleID int, entityID int) (int64, error) {
 	// Use tx (not r.db) so the version increment and tombstone insert are atomic.
 	version, err := r.nextSyncVersionWithDB(ctx, tx, circleID)
@@ -88,6 +103,107 @@ func (r *ChoreRepository) UpsertChore(c context.Context, chore *chModel.Chore) e
 	chore.SyncVersion = nextVersion
 	return r.db.WithContext(c).Model(&chore).Save(chore).Error
 }
+
+func choreViewerSet(chore *chModel.Chore, assigneeIDs []int, circleUserIDs []int) map[int]struct{} {
+	viewers := make(map[int]struct{})
+	if !chore.IsPrivate {
+		for _, userID := range circleUserIDs {
+			viewers[userID] = struct{}{}
+		}
+		return viewers
+	}
+
+	viewers[chore.CreatedBy] = struct{}{}
+	for _, userID := range assigneeIDs {
+		viewers[userID] = struct{}{}
+	}
+	return viewers
+}
+
+// UpdateChoreVisibility atomically updates a chore and its complete assignee set,
+// recording a user-scoped tombstone for each circle member who loses visibility.
+func (r *ChoreRepository) UpdateChoreVisibility(ctx context.Context, chore *chModel.Chore, assigneeIDs []int) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		locked := tx.WithContext(ctx)
+		if r.dbType == "postgres" {
+			locked = locked.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+
+		var previousChore chModel.Chore
+		if err := locked.Where("id = ? AND circle_id = ?", chore.ID, chore.CircleID).First(&previousChore).Error; err != nil {
+			return err
+		}
+
+		var previousAssignees []chModel.ChoreAssignees
+		if err := locked.Where("chore_id = ?", chore.ID).Find(&previousAssignees).Error; err != nil {
+			return err
+		}
+		previousAssigneeIDs := make([]int, 0, len(previousAssignees))
+		for _, assignee := range previousAssignees {
+			previousAssigneeIDs = append(previousAssigneeIDs, assignee.UserID)
+		}
+
+		var circleUserIDs []int
+		if err := tx.WithContext(ctx).Table("user_circles").Where("circle_id = ? AND is_active = ?", chore.CircleID, true).Pluck("user_id", &circleUserIDs).Error; err != nil {
+			return err
+		}
+
+		previousViewers := choreViewerSet(&previousChore, previousAssigneeIDs, circleUserIDs)
+		newViewers := choreViewerSet(chore, assigneeIDs, circleUserIDs)
+		revokedUserIDs := make([]int, 0)
+		for userID := range previousViewers {
+			if _, stillVisible := newViewers[userID]; !stillVisible {
+				revokedUserIDs = append(revokedUserIDs, userID)
+			}
+		}
+		sort.Ints(revokedUserIDs)
+
+		firstVersion, err := r.nextSyncVersionRangeWithDB(ctx, tx, chore.CircleID, 1+len(revokedUserIDs))
+		if err != nil {
+			return err
+		}
+		chore.SyncVersion = firstVersion
+		if err := tx.WithContext(ctx).Save(chore).Error; err != nil {
+			return err
+		}
+
+		if err := tx.WithContext(ctx).Where("chore_id = ?", chore.ID).Delete(&chModel.ChoreAssignees{}).Error; err != nil {
+			return err
+		}
+		assignees := make([]chModel.ChoreAssignees, 0, len(assigneeIDs))
+		seenAssignees := make(map[int]struct{}, len(assigneeIDs))
+		for _, userID := range assigneeIDs {
+			if _, exists := seenAssignees[userID]; exists {
+				continue
+			}
+			seenAssignees[userID] = struct{}{}
+			assignees = append(assignees, chModel.ChoreAssignees{ChoreID: chore.ID, UserID: userID})
+		}
+		if len(assignees) > 0 {
+			if err := tx.WithContext(ctx).Create(&assignees).Error; err != nil {
+				return err
+			}
+		}
+
+		tombstones := make([]syncModel.Tombstone, 0, len(revokedUserIDs))
+		for offset, userID := range revokedUserIDs {
+			tombstones = append(tombstones, syncModel.Tombstone{
+				CircleID:    chore.CircleID,
+				EntityType:  syncModel.EntityTypeChore,
+				EntityID:    chore.ID,
+				UserID:      &userID,
+				SyncVersion: firstVersion + int64(offset) + 1,
+			})
+		}
+		if len(tombstones) > 0 {
+			if err := tx.WithContext(ctx).Create(&tombstones).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 func (r *ChoreRepository) UpdateChorePriority(c context.Context, userID int, choreID int, priority int, circleID int) error {
 	nextVersion, err := r.nextSyncVersion(c, circleID)
 	if err != nil {
@@ -116,18 +232,8 @@ func (r *ChoreRepository) UpdateChoreFields(ctx context.Context, choreID int, fi
 	return r.db.WithContext(ctx).Model(&chModel.Chore{}).Where("id = ?", choreID).Updates(fields).Error
 }
 
-// nextSyncVersionRange atomically reserves a contiguous block of `count` sync
-// versions for a circle and returns the first (lowest) version in the range.
 func (r *ChoreRepository) nextSyncVersionRange(ctx context.Context, circleID int, count int) (int64, error) {
-	var endVersion int64
-	err := r.db.WithContext(ctx).Raw(`
-		INSERT INTO sync_cursors (circle_id, entity_type, max_version)
-		VALUES (?, ?, ?)
-		ON CONFLICT (circle_id, entity_type) DO UPDATE SET max_version = sync_cursors.max_version + ?
-		RETURNING max_version`,
-		circleID, syncModel.EntityTypeChore, count, count,
-	).Scan(&endVersion).Error
-	return endVersion - int64(count) + 1, err
+	return r.nextSyncVersionRangeWithDB(ctx, r.db, circleID, count)
 }
 
 func (r *ChoreRepository) UpdateChores(c context.Context, chores []*chModel.Chore) error {
@@ -233,12 +339,17 @@ func (r *ChoreRepository) GetArchivedChores(c context.Context, circleID int, use
 }
 
 func (r *ChoreRepository) DeleteChore(c context.Context, id int) (int64, error) {
-	var chore chModel.Chore
-	if err := r.db.WithContext(c).Select("id, circle_id").First(&chore, id).Error; err != nil {
-		return 0, err
-	}
 	var tombstoneSyncVersion int64
 	err := r.db.WithContext(c).Transaction(func(tx *gorm.DB) error {
+		query := tx.WithContext(c)
+		if r.dbType == "postgres" {
+			query = query.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+		var chore chModel.Chore
+		if err := query.Select("id, circle_id").First(&chore, id).Error; err != nil {
+			return err
+		}
+
 		// Delete all chore assignees
 		if err := tx.Where("chore_id = ?", id).Delete(&chModel.ChoreAssignees{}).Error; err != nil {
 			return err
@@ -1074,11 +1185,11 @@ func (r *ChoreRepository) DeleteTimeSession(c context.Context, sessionID int, ch
 
 }
 
-// GetTombstonesSince returns tombstones for a given circle and entity type with sync_version > since.
-func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, since int64, limit int) ([]*syncModel.Tombstone, error) {
+// GetTombstonesSince returns global tombstones and tombstones scoped to userID.
+func (r *ChoreRepository) GetTombstonesSince(c context.Context, circleID int, entityType syncModel.EntityType, userID int, since int64, limit int) ([]*syncModel.Tombstone, error) {
 	var tombstones []*syncModel.Tombstone
 	query := r.db.WithContext(c).
-		Where("circle_id = ? AND entity_type = ? AND sync_version > ?", circleID, entityType, since).
+		Where("circle_id = ? AND entity_type = ? AND sync_version > ? AND (user_id IS NULL OR user_id = ?)", circleID, entityType, since, userID).
 		Order("sync_version asc")
 	if limit > 0 {
 		query = query.Limit(limit)

--- a/internal/chore/repo/tombstone_test.go
+++ b/internal/chore/repo/tombstone_test.go
@@ -1,0 +1,198 @@
+package chore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"donetick.com/core/config"
+	chModel "donetick.com/core/internal/chore/model"
+	cModel "donetick.com/core/internal/circle/model"
+	syncModel "donetick.com/core/internal/sync/model"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newVisibilityTestRepository(t *testing.T) (*ChoreRepository, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&chModel.Chore{},
+		&chModel.ChoreAssignees{},
+		&cModel.UserCircle{},
+		&syncModel.SyncCursor{},
+		&syncModel.Tombstone{},
+	))
+
+	cfg := &config.Config{}
+	cfg.Database.Type = "sqlite"
+	return NewChoreRepository(db, cfg), db
+}
+
+func seedVisibilityTest(t *testing.T, db *gorm.DB, chore *chModel.Chore, assigneeIDs ...int) {
+	t.Helper()
+	for _, userID := range []int{1, 2, 3, 4} {
+		require.NoError(t, db.Create(&cModel.UserCircle{UserID: userID, CircleID: chore.CircleID, IsActive: true}).Error)
+	}
+	require.NoError(t, db.Create(chore).Error)
+	for _, userID := range assigneeIDs {
+		require.NoError(t, db.Create(&chModel.ChoreAssignees{ChoreID: chore.ID, UserID: userID}).Error)
+	}
+}
+
+func TestGetTombstonesSinceFiltersUserScope(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&syncModel.Tombstone{}))
+
+	userID := 7
+	otherUserID := 8
+	require.NoError(t, db.Create([]syncModel.Tombstone{
+		{CircleID: 1, EntityType: syncModel.EntityTypeChore, EntityID: 10, SyncVersion: 1},
+		{CircleID: 1, EntityType: syncModel.EntityTypeChore, EntityID: 11, UserID: &userID, SyncVersion: 2},
+		{CircleID: 1, EntityType: syncModel.EntityTypeChore, EntityID: 12, UserID: &otherUserID, SyncVersion: 3},
+	}).Error)
+
+	cfg := &config.Config{}
+	cfg.Database.Type = "sqlite"
+	repository := NewChoreRepository(db, cfg)
+	tombstones, err := repository.GetTombstonesSince(context.Background(), 1, syncModel.EntityTypeChore, userID, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, []int{10, 11}, []int{tombstones[0].EntityID, tombstones[1].EntityID})
+
+	otherUserTombstones, err := repository.GetTombstonesSince(context.Background(), 1, syncModel.EntityTypeChore, otherUserID, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, []int{10, 12}, []int{otherUserTombstones[0].EntityID, otherUserTombstones[1].EntityID})
+
+	firstPage, err := repository.GetTombstonesSince(context.Background(), 1, syncModel.EntityTypeChore, userID, 0, 1)
+	require.NoError(t, err)
+	require.Equal(t, []int{10}, []int{firstPage[0].EntityID})
+	secondPage, err := repository.GetTombstonesSince(context.Background(), 1, syncModel.EntityTypeChore, userID, firstPage[0].SyncVersion, 1)
+	require.NoError(t, err)
+	require.Equal(t, []int{11}, []int{secondPage[0].EntityID})
+}
+
+func TestUpdateChoreVisibilityPrivateAssigneeChanges(t *testing.T) {
+	t.Run("removed assignee is revoked", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true}
+		seedVisibilityTest(t, db, chore, 2, 3)
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, []int{3}))
+
+		var tombstones []syncModel.Tombstone
+		require.NoError(t, db.Find(&tombstones).Error)
+		require.Len(t, tombstones, 1)
+		require.Equal(t, 2, *tombstones[0].UserID)
+		require.Greater(t, tombstones[0].SyncVersion, chore.SyncVersion)
+	})
+
+	t.Run("retained assignee is not revoked", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true}
+		seedVisibilityTest(t, db, chore, 2)
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, []int{2}))
+
+		var count int64
+		require.NoError(t, db.Model(&syncModel.Tombstone{}).Count(&count).Error)
+		require.Zero(t, count)
+	})
+
+	t.Run("added assignee receives bumped private chore", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true}
+		seedVisibilityTest(t, db, chore, 2)
+		previousVersion := chore.SyncVersion
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, []int{2, 3}))
+		require.Greater(t, chore.SyncVersion, previousVersion)
+
+		var count int64
+		require.NoError(t, db.Model(&syncModel.Tombstone{}).Count(&count).Error)
+		require.Zero(t, count)
+
+		chores, err := repository.GetChores(context.Background(), chore.CircleID, 3, true, &SyncOptions{
+			SyncVersion: &previousVersion,
+			Limit:       10,
+		}, false)
+		require.NoError(t, err)
+		require.Len(t, chores, 1)
+		require.Equal(t, chore.ID, chores[0].ID)
+		require.Equal(t, chore.SyncVersion, chores[0].SyncVersion)
+	})
+
+	t.Run("creator remains visible without assignment", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true}
+		seedVisibilityTest(t, db, chore, 1, 2)
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, nil))
+
+		var tombstones []syncModel.Tombstone
+		require.NoError(t, db.Find(&tombstones).Error)
+		require.Len(t, tombstones, 1)
+		require.Equal(t, 2, *tombstones[0].UserID)
+	})
+}
+
+func TestUpdateChoreVisibilityPrivacyChanges(t *testing.T) {
+	t.Run("public to private revokes newly unauthorized users with distinct versions", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: false}
+		seedVisibilityTest(t, db, chore, 2)
+		chore.IsPrivate = true
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, []int{2}))
+
+		var tombstones []syncModel.Tombstone
+		require.NoError(t, db.Order("sync_version asc").Find(&tombstones).Error)
+		require.Len(t, tombstones, 2)
+		require.Equal(t, []int{3, 4}, []int{*tombstones[0].UserID, *tombstones[1].UserID})
+		require.Equal(t, chore.SyncVersion+1, tombstones[0].SyncVersion)
+		require.Equal(t, tombstones[0].SyncVersion+1, tombstones[1].SyncVersion)
+		var cursor syncModel.SyncCursor
+		require.NoError(t, db.Where("circle_id = ? AND entity_type = ?", chore.CircleID, syncModel.EntityTypeChore).First(&cursor).Error)
+		require.Equal(t, tombstones[1].SyncVersion, cursor.MaxVersion)
+	})
+
+	t.Run("private to public grants access without revocations", func(t *testing.T) {
+		repository, db := newVisibilityTestRepository(t)
+		chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true}
+		seedVisibilityTest(t, db, chore, 2)
+		chore.IsPrivate = false
+
+		require.NoError(t, repository.UpdateChoreVisibility(context.Background(), chore, []int{2}))
+
+		var count int64
+		require.NoError(t, db.Model(&syncModel.Tombstone{}).Count(&count).Error)
+		require.Zero(t, count)
+		require.Positive(t, chore.SyncVersion)
+	})
+}
+
+func TestUpdateChoreVisibilityRollsBackWhenTombstoneInsertFails(t *testing.T) {
+	repository, db := newVisibilityTestRepository(t)
+	chore := &chModel.Chore{ID: 10, CircleID: 1, CreatedBy: 1, IsPrivate: true, Name: "before"}
+	seedVisibilityTest(t, db, chore, 2)
+	require.NoError(t, db.Migrator().DropTable(&syncModel.Tombstone{}))
+	chore.Name = "after"
+
+	err := repository.UpdateChoreVisibility(context.Background(), chore, nil)
+	require.Error(t, err)
+
+	var storedChore chModel.Chore
+	require.NoError(t, db.First(&storedChore, chore.ID).Error)
+	require.Equal(t, "before", storedChore.Name)
+	var assignees []chModel.ChoreAssignees
+	require.NoError(t, db.Where("chore_id = ?", chore.ID).Find(&assignees).Error)
+	require.Len(t, assignees, 1)
+	require.Equal(t, 2, assignees[0].UserID)
+	var cursorCount int64
+	require.NoError(t, db.Model(&syncModel.SyncCursor{}).Count(&cursorCount).Error)
+	require.Zero(t, cursorCount)
+}

--- a/internal/sync/handler.go
+++ b/internal/sync/handler.go
@@ -65,7 +65,7 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 		chores = chores[:defaultSyncLimit]
 	}
 
-	choreTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChore, since, defaultSyncLimit+1)
+	choreTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChore, userID, since, defaultSyncLimit+1)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch deletions"})
 		return
@@ -86,7 +86,7 @@ func (h *SyncHandler) GetChanges(c *gin.Context) {
 		histories = histories[:defaultSyncLimit]
 	}
 
-	historyTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChoreHistory, since, defaultSyncLimit+1)
+	historyTombstones, err := h.choreRepo.GetTombstonesSince(c, circleID, syncModel.EntityTypeChoreHistory, userID, since, defaultSyncLimit+1)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to fetch history deletions"})
 		return

--- a/internal/sync/handler_test.go
+++ b/internal/sync/handler_test.go
@@ -1,0 +1,127 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"donetick.com/core/config"
+	chModel "donetick.com/core/internal/chore/model"
+	chRepo "donetick.com/core/internal/chore/repo"
+	cModel "donetick.com/core/internal/circle/model"
+	lModel "donetick.com/core/internal/label/model"
+	syncModel "donetick.com/core/internal/sync/model"
+	uModel "donetick.com/core/internal/user/model"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type syncResponse struct {
+	Changes struct {
+		Chores []chModel.Chore `json:"chores"`
+	} `json:"changes"`
+	Deletions struct {
+		Chores []int `json:"chores"`
+	} `json:"deletions"`
+	Cursor  int64 `json:"cursor"`
+	HasMore bool  `json:"hasMore"`
+}
+
+func newSyncHandlerTest(t *testing.T) (*chRepo.ChoreRepository, *gorm.DB, *gin.Engine) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&chModel.Chore{},
+		&chModel.ChoreAssignees{},
+		&chModel.ChoreHistory{},
+		&chModel.ChoreLabels{},
+		&chModel.TimeSession{},
+		&cModel.UserCircle{},
+		&lModel.Label{},
+		&syncModel.SyncCursor{},
+		&syncModel.Tombstone{},
+	))
+
+	cfg := &config.Config{}
+	cfg.Database.Type = "sqlite"
+	repository := chRepo.NewChoreRepository(db, cfg)
+	handler := NewHandler(repository)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("id", &uModel.UserDetails{User: uModel.User{ID: 2, CircleID: 1}})
+		c.Next()
+	})
+	router.GET("/sync/changes", handler.GetChanges)
+	return repository, db, router
+}
+
+func getSyncChanges(t *testing.T, router *gin.Engine, since int64) syncResponse {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/sync/changes?since=%d", since), nil)
+	router.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+	var response syncResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func TestGetChangesPaginatesScopedTombstonesWithoutSkippingBoundary(t *testing.T) {
+	_, db, router := newSyncHandlerTest(t)
+	tombstones := make([]syncModel.Tombstone, defaultSyncLimit+1)
+	userID := 2
+	for i := range tombstones {
+		tombstones[i] = syncModel.Tombstone{
+			CircleID:    1,
+			EntityType:  syncModel.EntityTypeChore,
+			EntityID:    i + 1,
+			UserID:      &userID,
+			SyncVersion: int64(i + 1),
+		}
+	}
+	require.NoError(t, db.Create(&tombstones).Error)
+
+	firstPage := getSyncChanges(t, router, 0)
+	require.True(t, firstPage.HasMore)
+	require.Equal(t, int64(defaultSyncLimit), firstPage.Cursor)
+	require.Len(t, firstPage.Deletions.Chores, defaultSyncLimit)
+	require.Equal(t, 1, firstPage.Deletions.Chores[0])
+	require.Equal(t, defaultSyncLimit, firstPage.Deletions.Chores[defaultSyncLimit-1])
+
+	secondPage := getSyncChanges(t, router, firstPage.Cursor)
+	require.False(t, secondPage.HasMore)
+	require.Equal(t, int64(defaultSyncLimit+1), secondPage.Cursor)
+	require.Equal(t, []int{defaultSyncLimit + 1}, secondPage.Deletions.Chores)
+}
+
+func TestGetChangesReturnsRevocationBeforeNewerRegrant(t *testing.T) {
+	repository, db, router := newSyncHandlerTest(t)
+	for _, userID := range []int{1, 2} {
+		require.NoError(t, db.Create(&cModel.UserCircle{UserID: userID, CircleID: 1, IsActive: true}).Error)
+	}
+	chore := &chModel.Chore{ID: 10, Name: "private chore", CircleID: 1, CreatedBy: 1, IsPrivate: true}
+	require.NoError(t, db.Create(chore).Error)
+	require.NoError(t, db.Create(&chModel.ChoreAssignees{ChoreID: chore.ID, UserID: 2}).Error)
+
+	require.NoError(t, repository.UpdateChoreVisibility(t.Context(), chore, nil))
+	var revocation syncModel.Tombstone
+	require.NoError(t, db.Where("entity_id = ? AND user_id = ?", chore.ID, 2).First(&revocation).Error)
+
+	require.NoError(t, repository.UpdateChoreVisibility(t.Context(), chore, []int{2}))
+	require.Greater(t, chore.SyncVersion, revocation.SyncVersion)
+
+	response := getSyncChanges(t, router, 0)
+	require.Equal(t, []int{chore.ID}, response.Deletions.Chores)
+	require.Len(t, response.Changes.Chores, 1)
+	require.Equal(t, chore.ID, response.Changes.Chores[0].ID)
+	require.Equal(t, chore.SyncVersion, response.Changes.Chores[0].SyncVersion)
+}

--- a/internal/sync/model/model.go
+++ b/internal/sync/model/model.go
@@ -16,8 +16,9 @@ const (
 
 type Tombstone struct {
 	ID          int        `json:"id" gorm:"primaryKey;autoIncrement"`
-	CircleID    int        `json:"circleId" gorm:"column:circle_id;not null;index:idx_tombstone_sync"`
-	EntityType  EntityType `json:"entityType" gorm:"column:entity_type;not null;index:idx_tombstone_sync"`
+	CircleID    int        `json:"circleId" gorm:"column:circle_id;not null;index:idx_tombstone_sync;index:idx_tombstone_retrieval,priority:1"`
+	EntityType  EntityType `json:"entityType" gorm:"column:entity_type;not null;index:idx_tombstone_sync;index:idx_tombstone_retrieval,priority:2"`
 	EntityID    int        `json:"entityId" gorm:"column:entity_id;not null;index:idx_tombstone_sync"`
-	SyncVersion int64      `json:"syncVersion" gorm:"column:sync_version;not null;index:idx_tombstone_sync"`
+	UserID      *int       `json:"-" gorm:"column:user_id;index:idx_tombstone_retrieval,priority:3"`
+	SyncVersion int64      `json:"syncVersion" gorm:"column:sync_version;not null;index:idx_tombstone_sync;index:idx_tombstone_retrieval,priority:4"`
 }


### PR DESCRIPTION
There is currently an issue when a user gains access to a task and is subsequently removed as an assignee. If the user is in offline mode and syncs later, the task does not receive updates and is never removed from their view. This change will add a tombstone record when a user is removed as an assignee.