### PR TITLE
Add timeout to Discord webhook client

### DIFF
--- a/internal/notifier/service/discord/discord.go
+++ b/internal/notifier/service/discord/discord.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"donetick.com/core/config"
 	chModel "donetick.com/core/internal/chore/model"
@@ -14,6 +15,8 @@ import (
 	uModel "donetick.com/core/internal/user/model"
 	"donetick.com/core/logging"
 )
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 type DiscordNotifier struct {
 }
@@ -63,7 +66,7 @@ func (dn *DiscordNotifier) sendMessage(c context.Context, webhookURL string, mes
 		return err
 	}
 
-	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonData))
+	resp, err := httpClient.Post(webhookURL, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		log.Error("Error sending message to Discord:", err)
 		return err


### PR DESCRIPTION
The Discord notifier sends webhooks with http.Post, which uses http.DefaultClient and has no timeout. The notification scheduler walks pending notifications one at a time (loadAndSendNotificationJob in scheduler.go), so if a configured webhook host is slow or just hangs the connection open, that Post blocks forever and stalls the whole scheduler goroutine, holding up everyone else's notifications too.

I gave it a package-level http.Client with a 30s Timeout and switched the call to use it. This matches what events/producer.go already does with its own client, so it keeps outbound HTTP behavior consistent across the codebase.