### PR TITLE
fix(chore): allow circle admins and managers to delete/archive chores

### DIFF
--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -1102,10 +1102,22 @@ func (h *Handler) DeleteChore(c *gin.Context) {
 		return
 	}
 	if chore.CreatedBy != currentUser.ID {
-		c.JSON(403, gin.H{
-			"error": "You are not allowed to delete this chore",
-		})
-		return
+		// Allow circle admins and managers to delete chores created by other
+		// members. See issue #760.
+		circleUsers, err := h.circleRepo.GetCircleUsers(c, currentUser.CircleID)
+		if err != nil {
+			logger.Error("Failed to retrieve circle users", "error", err)
+			c.JSON(500, gin.H{
+				"error": "Failed to retrieve circle users",
+			})
+			return
+		}
+		if !chore.CanDelete(currentUser.ID, circleUsers) {
+			c.JSON(403, gin.H{
+				"error": "You are not allowed to delete this chore",
+			})
+			return
+		}
 	}
 
 	// Collect file paths before deletion; the DeleteChore transaction removes the
@@ -2015,7 +2027,32 @@ func (h *Handler) ArchiveChore(c *gin.Context) {
 		return
 	}
 
-	err = h.choreRepo.ArchiveChore(c, id, currentUser.ID, currentUser.CircleID)
+	// Verify the user has permission to archive this chore (creator or
+	// circle admin/manager). See issue #760.
+	chore, err := h.choreRepo.GetChore(c, id, currentUser.ID, currentUser.CircleID)
+	if err != nil {
+		logger.Error("Failed to retrieve chore", "error", err)
+		c.JSON(500, gin.H{
+			"error": "Failed to retrieve chore",
+		})
+		return
+	}
+	circleUsers, err := h.circleRepo.GetCircleUsers(c, currentUser.CircleID)
+	if err != nil {
+		logger.Error("Failed to retrieve circle users", "error", err)
+		c.JSON(500, gin.H{
+			"error": "Failed to retrieve circle users",
+		})
+		return
+	}
+	if !chore.CanArchive(currentUser.ID, circleUsers) {
+		c.JSON(403, gin.H{
+			"error": "You are not allowed to archive this chore",
+		})
+		return
+	}
+
+	err = h.choreRepo.ArchiveChore(c, id, currentUser.CircleID)
 
 	if err != nil {
 		c.JSON(500, gin.H{
@@ -2079,7 +2116,32 @@ func (h *Handler) UnarchiveChore(c *gin.Context) {
 		})
 		return
 	}
-	err = h.choreRepo.UnarchiveChore(c, id, currentUser.ID, currentUser.CircleID)
+	// Verify the user has permission to unarchive this chore (creator or
+	// circle admin/manager). See issue #760.
+	chore, err := h.choreRepo.GetChore(c, id, currentUser.ID, currentUser.CircleID)
+	if err != nil {
+		logger.Error("Failed to retrieve chore", "error", err)
+		c.JSON(500, gin.H{
+			"error": "Failed to retrieve chore",
+		})
+		return
+	}
+	circleUsers, err := h.circleRepo.GetCircleUsers(c, currentUser.CircleID)
+	if err != nil {
+		logger.Error("Failed to retrieve circle users", "error", err)
+		c.JSON(500, gin.H{
+			"error": "Failed to retrieve circle users",
+		})
+		return
+	}
+	if !chore.CanArchive(currentUser.ID, circleUsers) {
+		c.JSON(403, gin.H{
+			"error": "You are not allowed to unarchive this chore",
+		})
+		return
+	}
+
+	err = h.choreRepo.UnarchiveChore(c, id, currentUser.CircleID)
 
 	if err != nil {
 		c.JSON(500, gin.H{

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -208,6 +208,27 @@ type ChoreLiteReq struct { // TODO: Remove this when api is removed.
 	CreatedBy   *int    `json:"createdBy,omitempty"`
 }
 
+// CanDelete returns true if the user is the chore creator or an admin/manager
+// in the chore's circle. This allows circle administrators to manage chores
+// created by other members who may become unavailable.
+func (c *Chore) CanDelete(userID int, circleUsers []*cModel.UserCircleDetail) bool {
+	if userID == c.CreatedBy {
+		return true
+	}
+	for _, cu := range circleUsers {
+		if cu.UserID == userID && (cu.Role == cModel.UserRoleAdmin || cu.Role == cModel.UserRoleManager) {
+			return true
+		}
+	}
+	return false
+}
+
+// CanArchive returns true if the user is the chore creator or an admin/manager
+// in the chore's circle. Uses the same permission policy as CanDelete.
+func (c *Chore) CanArchive(userID int, circleUsers []*cModel.UserCircleDetail) bool {
+	return c.CanDelete(userID, circleUsers)
+}
+
 func (c *Chore) CanDeleteHistory(
 	userID int,
 	circleUsers []*cModel.UserCircleDetail,

--- a/internal/chore/model/permission_test.go
+++ b/internal/chore/model/permission_test.go
@@ -1,0 +1,126 @@
+package model
+
+import (
+	"testing"
+
+	cModel "donetick.com/core/internal/circle/model"
+)
+
+func TestCanDelete(t *testing.T) {
+	chore := &Chore{CreatedBy: 1}
+
+	tests := []struct {
+		name        string
+		userID      int
+		circleUsers []*cModel.UserCircleDetail
+		want        bool
+	}{
+		{
+			name:   "creator can delete",
+			userID: 1,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 1, Role: cModel.UserRoleMember}},
+			},
+			want: true,
+		},
+		{
+			name:   "admin can delete non-owned chore",
+			userID: 2,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 2, Role: cModel.UserRoleAdmin}},
+			},
+			want: true,
+		},
+		{
+			name:   "manager can delete non-owned chore",
+			userID: 3,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 3, Role: cModel.UserRoleManager}},
+			},
+			want: true,
+		},
+		{
+			name:   "member cannot delete non-owned chore",
+			userID: 4,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 4, Role: cModel.UserRoleMember}},
+			},
+			want: false,
+		},
+		{
+			name:        "user not in circle cannot delete",
+			userID:      99,
+			circleUsers: []*cModel.UserCircleDetail{},
+			want:        false,
+		},
+		{
+			name:   "member with different user ID cannot delete",
+			userID: 5,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 6, Role: cModel.UserRoleAdmin}},
+				{UserCircle: cModel.UserCircle{UserID: 5, Role: cModel.UserRoleMember}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chore.CanDelete(tt.userID, tt.circleUsers); got != tt.want {
+				t.Errorf("CanDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanArchive(t *testing.T) {
+	chore := &Chore{CreatedBy: 1}
+
+	tests := []struct {
+		name        string
+		userID      int
+		circleUsers []*cModel.UserCircleDetail
+		want        bool
+	}{
+		{
+			name:   "creator can archive",
+			userID: 1,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 1, Role: cModel.UserRoleMember}},
+			},
+			want: true,
+		},
+		{
+			name:   "admin can archive non-owned chore",
+			userID: 2,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 2, Role: cModel.UserRoleAdmin}},
+			},
+			want: true,
+		},
+		{
+			name:   "manager can archive non-owned chore",
+			userID: 3,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 3, Role: cModel.UserRoleManager}},
+			},
+			want: true,
+		},
+		{
+			name:   "member cannot archive non-owned chore",
+			userID: 4,
+			circleUsers: []*cModel.UserCircleDetail{
+				{UserCircle: cModel.UserCircle{UserID: 4, Role: cModel.UserRoleMember}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chore.CanArchive(tt.userID, tt.circleUsers); got != tt.want {
+				t.Errorf("CanArchive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -989,12 +989,12 @@ func (r *ChoreRepository) GetChoreDetailByID(c context.Context, choreID int, cir
 	return &choreDetail, nil
 }
 
-func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, userID int, circleID int) error {
+func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, circleID int) error {
 	nextVersion, err := r.nextSyncVersion(c, circleID)
 	if err != nil {
 		return err
 	}
-	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ? AND circle_id = ?", choreID, userID, circleID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 		"is_active":    false,
 		"sync_version": nextVersion,
 	})
@@ -1004,12 +1004,12 @@ func (r *ChoreRepository) ArchiveChore(c context.Context, choreID int, userID in
 	return result.Error
 }
 
-func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, userID int, circleID int) error {
+func (r *ChoreRepository) UnarchiveChore(c context.Context, choreID int, circleID int) error {
 	nextVersion, err := r.nextSyncVersion(c, circleID)
 	if err != nil {
 		return err
 	}
-	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND created_by = ? AND circle_id = ?", choreID, userID, circleID).Updates(map[string]interface{}{
+	result := r.db.WithContext(c).Model(&chModel.Chore{}).Where("id = ? AND circle_id = ?", choreID, circleID).Updates(map[string]interface{}{
 		"is_active":    true,
 		"sync_version": nextVersion,
 	})


### PR DESCRIPTION
## Summary

Currently, only the creator of a chore can delete, archive, or unarchive it. This means circle admins and managers cannot manage chores created by other members who may become unavailable or stop using the app.

This PR extends the permission model so that circle admins and managers can also delete, archive, and unarchive chores — consistent with the existing pattern used for chore history deletion (`CanDeleteHistory`) and chore editing (`CanEdit`), both of which already allow admin/manager access.

Closes #760.

## Changes

- **`internal/chore/model/model.go`**: Add `CanDelete` and `CanArchive` methods to `Chore`. These return `true` if the user is the chore creator **or** holds an admin/manager role in the chore's circle (via `circleUsers`).
- **`internal/chore/handler.go`** (`DeleteChore`): When the current user is not the chore creator, fetch `circleUsers` and check `chore.CanDelete()` before proceeding. Previously this was a hard `403` for any non-creator.
- **`internal/chore/handler.go`** (`ArchiveChore`, `UnarchiveChore`): Add a permission check using `chore.CanArchive()` before calling the repo. Previously there was no handler-level check — the repo silently refused via a `created_by` WHERE clause that returned 0 rows affected.
- **`internal/chore/repo/repository.go`**: Remove the `created_by` filter and `userID` parameter from `ArchiveChore` and `UnarchiveChore`. Permission is now enforced at the handler level; the repo only scopes by `choreID` and `circleID`.
- **`internal/chore/model/permission_test.go`**: Unit tests for `CanDelete` and `CanArchive` covering creator, admin, manager, member, and non-circle-user scenarios.

## Design Rationale

The permission check is placed at the handler level (not the repo) to follow the existing pattern in this codebase — `CanEdit`, `CanView`, `CanComplete`, and `CanDeleteHistory` are all model-level checks called from handlers. The repo methods are kept simple (scoped by circle only) to avoid duplicating permission logic across layers.

Admin and manager roles are treated identically, matching the existing `IsAdminOrManager()` helper used for chore history operations.

## Test Plan

- [x] `go build ./internal/chore/...` passes
- [x] `go vet ./internal/chore/... ./internal/circle/...` passes
- [x] `go test ./internal/chore/...` — all existing and new tests pass
- [x] Manual: admin can delete a chore created by another member
- [x] Manual: admin can archive/unarchive a chore created by another member
- [x] Manual: regular member still gets 403 on non-owned chores

Tested the fix end-to-end on a self-hosted instance:

### Pre-existing frontend note

When a delete fails with 403, the frontend optimistically removes the chore from the list and only restores it on page reload. This is a pre-existing frontend issue (not introduced by this PR) — the delete error response isn't handled gracefully in the UI. Worth addressing separately.