### PR TITLE
fix(db): check existence of labels and notification_meta columns

### DIFF
--- a/migrations/20241123_migrate_label_to_labels_v2.go
+++ b/migrations/20241123_migrate_label_to_labels_v2.go
@@ -48,10 +48,11 @@ func (m MigrateLabels20241123) Up(ctx context.Context, db *gorm.DB) error {
 
 	// Start a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Get all chores with labels
 		if !tx.Migrator().HasColumn("chores", "labels") {
-    	return nil
+			return nil
 		}
+
+		// Get all chores with labels
 		var choreRecords []Chore
 		if err := tx.Table("chores").Select("id, labels, circle_id, created_by").Find(&choreRecords).Error; err != nil {
 			log.Errorf("Failed to fetch chores with label: %v", err)

--- a/migrations/20241123_migrate_label_to_labels_v2.go
+++ b/migrations/20241123_migrate_label_to_labels_v2.go
@@ -49,6 +49,9 @@ func (m MigrateLabels20241123) Up(ctx context.Context, db *gorm.DB) error {
 	// Start a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
 		// Get all chores with labels
+		if !tx.Migrator().HasColumn("chores", "labels") {
+    	return nil
+		}
 		var choreRecords []Chore
 		if err := tx.Table("chores").Select("id, labels, circle_id, created_by").Find(&choreRecords).Error; err != nil {
 			log.Errorf("Failed to fetch chores with label: %v", err)

--- a/migrations/20250314_fix_notification_metadata_experiment_modal.go
+++ b/migrations/20250314_fix_notification_metadata_experiment_modal.go
@@ -23,11 +23,15 @@ func (m MigrateFixNotificationMetadataExperimentModal20241212) Down(ctx context.
 
 func (m MigrateFixNotificationMetadataExperimentModal20241212) Up(ctx context.Context, db *gorm.DB) error {
 	log := logging.FromContext(ctx)
+	
 
 	// Start a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Update all chore where notification metadata is a null stirng 'null' to empty json {}:
+		if !tx.Migrator().HasColumn("chores", "notification_meta") {
+    	return nil
+		}
 
+		// Update all chore where notification metadata is a null stirng 'null' to empty json {}:
 		if err := tx.Table("chores").Where("notification_meta = ?", "null").Update("notification_meta", "{}").Error; err != nil {
 			log.Errorf("Failed to update chores with null notification metadata: %v", err)
 			return err

--- a/migrations/20250314_fix_notification_metadata_experiment_modal.go
+++ b/migrations/20250314_fix_notification_metadata_experiment_modal.go
@@ -28,7 +28,7 @@ func (m MigrateFixNotificationMetadataExperimentModal20241212) Up(ctx context.Co
 	// Start a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
 		if !tx.Migrator().HasColumn("chores", "notification_meta") {
-    	return nil
+			return nil
 		}
 
 		// Update all chore where notification metadata is a null stirng 'null' to empty json {}:


### PR DESCRIPTION
As reported in this [issue](https://github.com/donetick/donetick/issues/782), migrations where failing because of the lack of the following columns: `labels` and  `notification_meta`.
Just checking via Gorm if they exists and in case returning nil to report as completed migrations.