### PR TITLE
Standardize API key format with hashed storage and dt_ prefix (#798)

### DIFF
--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -1031,18 +1031,32 @@ func (h *Handler) CreateLongLivedToken(c *gin.Context) {
 		return
 	}
 
-	timestamp := time.Now().UTC().Unix()
-	hashInput := fmt.Sprintf("%s:%d:%x", currentUser.Username, timestamp, randomBytes)
-	hash := sha256.Sum256([]byte(hashInput))
-	token := hex.EncodeToString(hash[:])
+	tokenBody := hex.EncodeToString(randomBytes)
 
-	tokenModel, err := h.userRepo.StoreAPIToken(c, currentUser.ID, req.Name, token)
+	tokenModel, err := h.userRepo.StoreAPIToken(c, currentUser.ID, req.Name, tokenBody, uModel.APITokenPrefix)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to store the token"})
 		return
 	}
 
-	response := gin.H{"res": tokenModel}
+	type createTokenResponse struct {
+		ID        int       `json:"id"`
+		Name      string    `json:"name"`
+		UserID    int       `json:"userId"`
+		Token     string    `json:"token"`
+		Prefix    *string   `json:"prefix"`
+		CreatedAt time.Time `json:"createdAt"`
+	}
+	resModel := createTokenResponse{
+		ID:        tokenModel.ID,
+		Name:      tokenModel.Name,
+		UserID:    tokenModel.UserID,
+		Token:     uModel.BuildFullToken(uModel.APITokenPrefix, tokenBody),
+		Prefix:    tokenModel.Prefix,
+		CreatedAt: tokenModel.CreatedAt,
+	}
+
+	response := gin.H{"res": resModel}
 
 	// If user has MFA enabled but didn't provide a code, suggest using MFA for enhanced security
 	if currentUser.MFAEnabled && req.MFACode == "" {
@@ -1051,6 +1065,8 @@ func (h *Handler) CreateLongLivedToken(c *gin.Context) {
 
 	c.JSON(http.StatusOK, response)
 }
+
+const tokenMask = "********" // Used for masking the token to display it after creation (8 asterisks)
 
 func (h *Handler) GetAllUserToken(c *gin.Context) {
 	currentUser, ok := auth.CurrentUser(c)
@@ -1065,7 +1081,28 @@ func (h *Handler) GetAllUserToken(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"res": tokens})
+	type listTokenResponse struct {
+		ID          int       `json:"id"`
+		Name        string    `json:"name"`
+		UserID      int       `json:"userId"`
+		MaskedToken *string   `json:"maskedToken"`
+		CreatedAt   time.Time `json:"createdAt"`
+	}
+	resModels := make([]listTokenResponse, len(tokens))
+	for i := range tokens {
+		resModels[i] = listTokenResponse{
+			ID:        tokens[i].ID,
+			Name:      tokens[i].Name,
+			UserID:    tokens[i].UserID,
+			CreatedAt: tokens[i].CreatedAt,
+		}
+		if tokens[i].Prefix != nil && tokens[i].Suffix != nil {
+			maskedToken := fmt.Sprintf("%s%s%s", *tokens[i].Prefix, tokenMask, *tokens[i].Suffix)
+			resModels[i].MaskedToken = &maskedToken
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"res": resModels})
 
 }
 

--- a/internal/user/model/model.go
+++ b/internal/user/model/model.go
@@ -55,7 +55,15 @@ type APIToken struct {
 	Name      string    `json:"name" gorm:"column:name"`            // Name (display only, not unique)
 	UserID    int       `json:"userId" gorm:"column:user_id;index"` // Index on userID
 	Token     string    `json:"token" gorm:"column:token;index"`    // Index on token
+	Prefix    *string   `json:"prefix" gorm:"column:prefix"`        // Token format/type marker, e.g. "dt_"
+	Suffix    *string   `json:"suffix" gorm:"column:suffix"`        // Last few chars of the token, for masked display
 	CreatedAt time.Time `json:"createdAt" gorm:"column:created_at"`
+}
+
+const APITokenPrefix = "dt_"
+
+func BuildFullToken(prefix, body string) string {
+	return prefix + body
 }
 
 type UserNotificationTarget struct {

--- a/internal/user/repo/repository.go
+++ b/internal/user/repo/repository.go
@@ -2,8 +2,12 @@ package user
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"donetick.com/core/config"
@@ -219,24 +223,39 @@ func (r *UserRepository) UpdatePasswordByToken(ctx context.Context, email string
 	return nil
 }
 
-func (r *UserRepository) StoreAPIToken(c context.Context, userID int, name string, tokenCode string) (*uModel.APIToken, error) {
-	token := &uModel.APIToken{
+func (r *UserRepository) StoreAPIToken(c context.Context, userID int, name string, tokenBody string, tokenPrefix string) (*uModel.APIToken, error) {
+	fullToken := uModel.BuildFullToken(tokenPrefix, tokenBody)
+
+	hashHex := hashAPIToken(fullToken)
+
+	if len(tokenBody) < 4 {
+		return nil, errors.New("token body too short to derive a suffix")
+	}
+	suffix := tokenBody[len(tokenBody)-4:]
+
+	apiToken := &uModel.APIToken{
 		UserID:    userID,
 		Name:      name,
-		Token:     tokenCode,
+		Token:     hashHex,
+		Prefix:    &tokenPrefix,
+		Suffix:    &suffix,
 		CreatedAt: time.Now().UTC(),
 	}
 	if err := r.db.WithContext(c).Model(&uModel.APIToken{}).Save(
-		token).Error; err != nil {
+		apiToken).Error; err != nil {
 		return nil, err
 
 	}
-	return token, nil
+	return apiToken, nil
 }
 
 func (r *UserRepository) GetUserByToken(c context.Context, token string) (*uModel.UserDetails, error) {
 	var user *uModel.UserDetails
 	now := time.Now().UTC()
+
+	if strings.HasPrefix(token, uModel.APITokenPrefix) {
+		token = hashAPIToken(token)
+	}
 
 	if r.isDonetickDotCom {
 		if err := r.db.WithContext(c).Table("users u").Select("u.*, s.status as subscription, s.expires_at as expiration, c.webhook_url as webhook_url").Joins("left join api_tokens at on at.user_id = u.id").Joins("left join subscriptions s on s.circle_id = u.circle_id AND s.status = 'active' AND (s.expires_at IS NULL OR s.expires_at > ?)", now).Joins("left join circles c on c.id = u.circle_id").Where("at.token = ?", token).First(&user).Error; err != nil {
@@ -254,6 +273,12 @@ func (r *UserRepository) GetUserByToken(c context.Context, token string) (*uMode
 	}
 
 	return user, nil
+}
+
+// Hashes a full raw token for storage (on creation) and lookup comparison (on verification)
+func hashAPIToken(rawToken string) string {
+	hashBytes := sha256.Sum256([]byte(rawToken))
+	return hex.EncodeToString(hashBytes[:])
 }
 
 func (r *UserRepository) GetAllUserTokens(c context.Context, userID int) ([]*uModel.APIToken, error) {


### PR DESCRIPTION
Closes #798

## What this does
- Adopts a standard `dt_` prefix for new API tokens, followed by a high-entropy random body
- Stores only a SHA-256 hash of the full token server-side. The full token is now returned to the user exactly once, at creation time
- Added `prefix` and `suffix` fields on the token model so the list endpoint can return a masked version (e.g. `dt_********ab12`) instead of ever exposing the raw token again
- Token verification (`GetUserByToken`) now detects the `dt_` prefix and hashes before lookup. Tokens without the prefix still go through the legacy raw-token comparison, so that the tokens issued before this change keep working with no migration required.

## What I left out
`last_used_at` was listed as optional in the issue, so I left it out of this PR. `GetUserByToken` runs on every authenticated request, so recording a timestamp there means adding a write to what's currently a pure read, on a very hot path. There's a few things to decide: whether to limit how often it writes, and whether that write should happen synchronously or in the background. Didn't want to guess at either one without discussing it, happy to take it on as a follow-up.

## Testing
- `go build`, `go vet`, and the full test suite all pass
- Created a new token via the API and confirmed the response format (`dt_` + hex body), and that the DB stores only the SHA-256 hash (never the raw token)
- Confirmed a newly created token successfully authenticates a request
- Simulated a legacy (pre-change) token and confirmed it still authenticates via the fallback comparison

Note: I tested this manually via curl rather than writing automated tests, happy to add unit tests for the hashing/verification logic if that's preferred.
