### PR TITLE
fix(scheduler): evaluate recurrences in the chore's timezone

### DIFF
--- a/internal/chore/scheduler.go
+++ b/internal/chore/scheduler.go
@@ -17,14 +17,23 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 		return nil, nil
 	}
 
+	// Evaluate the whole schedule in the chore's own timezone. Doing the
+	// arithmetic in UTC pins every recurrence to a fixed UTC hour, so the
+	// local time of a chore shifts by an hour on daylight saving transitions
+	// and stays wrong afterwards.
+	// choreLocation falls back to time.UTC when no timezone is configured,
+	// which keeps the behaviour unchanged for chores created before
+	// timezones were stored.
+	loc := choreLocation(ctx, chore)
+
 	var baseDate time.Time
 	if chore.NextDueDate != nil {
-		baseDate = chore.NextDueDate.UTC()
+		baseDate = chore.NextDueDate.In(loc)
 	} else {
-		baseDate = completedDate.UTC()
+		baseDate = completedDate.In(loc)
 	}
 	if chore.IsRolling {
-		baseDate = completedDate.UTC()
+		baseDate = completedDate.In(loc)
 	}
 
 	// Handle time-based frequencies, ensure time is in the future
@@ -37,14 +46,18 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 
 			// fallback to use the next due date time if available:
 			if chore.NextDueDate != nil {
-				t = chore.NextDueDate.UTC()
+				t = *chore.NextDueDate
 			} else {
-				t = time.Now().UTC()
+				t = time.Now()
 			}
 
 		}
-		t = t.UTC()
-		baseDate = time.Date(baseDate.Year(), baseDate.Month(), baseDate.Day(), t.Hour(), t.Minute(), t.Second(), 0, time.UTC)
+		t = t.In(loc)
+		// Note: for the one hour that a DST transition skips or repeats,
+		// time.Date normalises to a neighbouring instant. Go does not
+		// guarantee which one, but it does not error either, so a chore
+		// scheduled inside that hour still gets a valid due date.
+		baseDate = time.Date(baseDate.Year(), baseDate.Month(), baseDate.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc)
 	}
 
 	switch chore.FrequencyType {
@@ -85,31 +98,14 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 
 		// Default to every_week if no pattern specified
 		if weekPattern == nil || *weekPattern == "" || *weekPattern == "every_week" {
-			// Get timezone for calculations - prefer chore timezone, fallback to UTC
-			var loc *time.Location
-			var err error
-			if chore.FrequencyMetadataV2.Timezone != "" {
-				loc, err = time.LoadLocation(chore.FrequencyMetadataV2.Timezone)
-				if err != nil {
-					log := logging.FromContext(ctx)
-					log.Error("error loading timezone from frequency metadata", "error", err, "timezone", chore.FrequencyMetadataV2.Timezone, "chore_id", chore.ID)
-					loc = time.UTC // fallback to UTC
-				}
-			} else {
-				loc = time.UTC
-			}
-
-			// Convert baseDate to the target timezone for weekday calculations
-			baseDateInTimezone := baseDate.In(loc)
-
-			// Find the next valid day of the week in the target timezone
+			// Find the next valid day of the week in the chore's timezone
 			for i := 1; i <= 7; i++ {
-				nextDueDateInTimezone := baseDateInTimezone.AddDate(0, 0, i)
-				nextDay := strings.ToLower(nextDueDateInTimezone.Weekday().String())
+				nextDueDate := baseDate.AddDate(0, 0, i)
+				nextDay := strings.ToLower(nextDueDate.Weekday().String())
 				for _, day := range chore.FrequencyMetadataV2.Days {
 					if strings.ToLower(*day) == nextDay {
 						// Convert back to UTC for storage
-						nextDueDateUTC := nextDueDateInTimezone.UTC()
+						nextDueDateUTC := nextDueDate.UTC()
 						return &nextDueDateUTC, nil
 					}
 				}
@@ -123,7 +119,8 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 			if len(occurrences) == 0 {
 				return nil, fmt.Errorf("week_of_month requires at least one occurrence")
 			}
-			return findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, true)
+			nextDueDate, err := findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, true)
+			return toUTC(nextDueDate, err)
 		}
 
 		// Handle week_of_quarter pattern
@@ -132,7 +129,8 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 			if len(occurrences) == 0 {
 				return nil, fmt.Errorf("week_of_quarter requires at least one occurrence")
 			}
-			return findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, false)
+			nextDueDate, err := findNextDueDateForOccurrencePattern(baseDate, chore.FrequencyMetadataV2.Days, occurrences, false)
+			return toUTC(nextDueDate, err)
 		}
 
 		return nil, fmt.Errorf("invalid week pattern: %s", *weekPattern)
@@ -177,11 +175,13 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 				targetDay = lastDayOfMonth
 			}
 
-			nextDueDate = time.Date(nextDueDate.Year(), time.Month(nextMonth), targetDay, nextDueDate.Hour(), nextDueDate.Minute(), 0, 0, time.UTC)
+			nextDueDate = time.Date(nextDueDate.Year(), time.Month(nextMonth), targetDay, nextDueDate.Hour(), nextDueDate.Minute(), 0, 0, loc)
 
 			for _, month := range chore.FrequencyMetadataV2.Months {
 				if strings.EqualFold(*month, time.Month(nextMonth).String()) {
-					return &nextDueDate, nil
+					// Convert back to UTC for storage
+					nextDueDateUTC := nextDueDate.UTC()
+					return &nextDueDateUTC, nil
 				}
 			}
 		}
@@ -190,7 +190,39 @@ func scheduleNextDueDate(ctx context.Context, chore *chModel.Chore, completedDat
 		return nil, fmt.Errorf("invalid frequency type: %s", chore.FrequencyType)
 	}
 
-	return &baseDate, nil
+	// Convert back to UTC for storage
+	baseDateUTC := baseDate.UTC()
+	return &baseDateUTC, nil
+}
+
+// choreLocation returns the time.Location a chore's schedule should be
+// evaluated in. It falls back to UTC when no timezone is configured or when
+// the configured timezone cannot be loaded, which preserves the previous
+// behaviour for chores created before timezones were stored.
+func choreLocation(ctx context.Context, chore *chModel.Chore) *time.Location {
+	if chore.FrequencyMetadataV2 == nil || chore.FrequencyMetadataV2.Timezone == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(chore.FrequencyMetadataV2.Timezone)
+	if err != nil {
+		log := logging.FromContext(ctx)
+		log.Error("error loading timezone from frequency metadata",
+			"error", err,
+			"timezone", chore.FrequencyMetadataV2.Timezone,
+			"chore_id", chore.ID)
+		return time.UTC
+	}
+	return loc
+}
+
+// toUTC normalises a computed due date to UTC for storage, passing through
+// any error unchanged.
+func toUTC(t *time.Time, err error) (*time.Time, error) {
+	if err != nil || t == nil {
+		return t, err
+	}
+	utc := t.UTC()
+	return &utc, nil
 }
 
 // getOccurrences returns the occurrences from metadata, supporting both new and legacy formats

--- a/internal/chore/scheduler_test.go
+++ b/internal/chore/scheduler_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
+	_ "time/tzdata"
 	chModel "donetick.com/core/internal/chore/model"
 )
 
@@ -660,5 +660,171 @@ func TestScheduleNextDueDateWeekPatterns(t *testing.T) {
 				t.Errorf("scheduleNextDueDate() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- DST regression tests -------------------------------------------------
+//
+// Europe/Berlin switches CEST -> CET on 2026-10-25 and CET -> CEST on
+// 2026-03-29. A chore configured for a given local time of day must keep
+// that local time across both transitions.
+//
+// Note on constructing these cases: frequencyMetadata.Time must carry the
+// offset that was in effect when the chore was created, not the offset of
+// the base date. Deriving Time from the base date hides the bug, because
+// the UTC hour then happens to match.
+
+func TestScheduleNextDueDateDSTAutumnDaily(t *testing.T) {
+	berlin := mustLoadBerlin(t)
+
+	// Created in summer: 06:45 CEST == 04:45 UTC
+	createdAt := time.Date(2026, 7, 1, 6, 45, 0, 0, berlin)
+	// Last due the day before the transition
+	lastDue := time.Date(2026, 10, 24, 6, 45, 0, 0, berlin)
+
+	chore := chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeDaily,
+		Frequency:     1,
+		NextDueDate:   timePtr(lastDue),
+		FrequencyMetadataV2: &chModel.FrequencyMetadata{
+			Time:     createdAt.Format(time.RFC3339),
+			Timezone: "Europe/Berlin",
+		},
+	}
+
+	got, err := scheduleNextDueDate(context.Background(), &chore, lastDue)
+	if err != nil {
+		t.Fatalf("scheduleNextDueDate() error = %v", err)
+	}
+	assertLocalTime(t, got, berlin, 2026, 10, 25, 6, 45)
+}
+
+func TestScheduleNextDueDateDSTAutumnDaysOfWeek(t *testing.T) {
+	berlin := mustLoadBerlin(t)
+
+	createdAt := time.Date(2026, 7, 1, 6, 45, 0, 0, berlin)
+	// Monday after the transition; the next occurrence is the one that drifts
+	lastDue := time.Date(2026, 10, 26, 6, 45, 0, 0, berlin)
+	monday := "monday"
+
+	chore := chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
+		Frequency:     1,
+		NextDueDate:   timePtr(lastDue),
+		FrequencyMetadataV2: &chModel.FrequencyMetadata{
+			Days:     []*string{&monday},
+			Time:     createdAt.Format(time.RFC3339),
+			Timezone: "Europe/Berlin",
+		},
+	}
+
+	got, err := scheduleNextDueDate(context.Background(), &chore, lastDue)
+	if err != nil {
+		t.Fatalf("scheduleNextDueDate() error = %v", err)
+	}
+	assertLocalTime(t, got, berlin, 2026, 11, 2, 6, 45)
+}
+
+func TestScheduleNextDueDateDSTSpringInterval(t *testing.T) {
+	berlin := mustLoadBerlin(t)
+
+	// Created in winter: 06:45 CET == 05:45 UTC
+	createdAt := time.Date(2026, 1, 15, 6, 45, 0, 0, berlin)
+	lastDue := time.Date(2026, 3, 27, 6, 45, 0, 0, berlin)
+	unit := "days"
+
+	chore := chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeInterval,
+		Frequency:     3,
+		NextDueDate:   timePtr(lastDue),
+		FrequencyMetadataV2: &chModel.FrequencyMetadata{
+			Unit:     &unit,
+			Time:     createdAt.Format(time.RFC3339),
+			Timezone: "Europe/Berlin",
+		},
+	}
+
+	got, err := scheduleNextDueDate(context.Background(), &chore, lastDue)
+	if err != nil {
+		t.Fatalf("scheduleNextDueDate() error = %v", err)
+	}
+	// 27.03. + 3 days = 30.03., after the CET -> CEST transition
+	assertLocalTime(t, got, berlin, 2026, 3, 30, 6, 45)
+}
+
+// TestScheduleNextDueDateWithoutTimezoneUnchanged guards the backwards
+// compatible path: without a configured timezone the scheduler must behave
+// exactly as before, i.e. purely in UTC.
+func TestScheduleNextDueDateWithoutTimezoneUnchanged(t *testing.T) {
+	lastDue := time.Date(2026, 10, 19, 8, 30, 0, 0, time.UTC)
+	monday := "monday"
+
+	chore := chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
+		Frequency:     1,
+		NextDueDate:   timePtr(lastDue),
+		FrequencyMetadataV2: &chModel.FrequencyMetadata{
+			Days: []*string{&monday},
+			Time: lastDue.Format(time.RFC3339),
+			// no Timezone on purpose
+		},
+	}
+
+	got, err := scheduleNextDueDate(context.Background(), &chore, lastDue)
+	if err != nil {
+		t.Fatalf("scheduleNextDueDate() error = %v", err)
+	}
+	want := time.Date(2026, 10, 26, 8, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("scheduleNextDueDate() = %v, want %v", got.UTC(), want)
+	}
+}
+
+// TestScheduleNextDueDateInvalidTimezoneFallsBackToUTC ensures a bad
+// timezone string does not break scheduling.
+func TestScheduleNextDueDateInvalidTimezoneFallsBackToUTC(t *testing.T) {
+	lastDue := time.Date(2026, 10, 19, 8, 30, 0, 0, time.UTC)
+	monday := "monday"
+
+	chore := chModel.Chore{
+		FrequencyType: chModel.FrequencyTypeDayOfTheWeek,
+		Frequency:     1,
+		NextDueDate:   timePtr(lastDue),
+		FrequencyMetadataV2: &chModel.FrequencyMetadata{
+			Days:     []*string{&monday},
+			Time:     lastDue.Format(time.RFC3339),
+			Timezone: "Not/AZone",
+		},
+	}
+
+	got, err := scheduleNextDueDate(context.Background(), &chore, lastDue)
+	if err != nil {
+		t.Fatalf("scheduleNextDueDate() error = %v", err)
+	}
+	want := time.Date(2026, 10, 26, 8, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("scheduleNextDueDate() = %v, want %v", got.UTC(), want)
+	}
+}
+
+func mustLoadBerlin(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("loading Europe/Berlin failed despite embedded tzdata: %v", err)
+	}
+	return loc
+}
+
+func assertLocalTime(t *testing.T, got *time.Time, loc *time.Location,
+	year int, month time.Month, day, hour, minute int) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("scheduleNextDueDate() returned nil")
+	}
+	want := time.Date(year, month, day, hour, minute, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Errorf("scheduleNextDueDate() = %v (local %v), want %v (local %v)",
+			got.UTC(), got.In(loc), want.UTC(), want)
 	}
 }


### PR DESCRIPTION
Fixes #808

## What this fixes

Recurring chores drift by one hour across DST transitions. A chore set to
06:45 local time starts firing at 05:45 after the autumn transition and
07:45 after the spring one, and every subsequent occurrence keeps the wrong
local time.

`frequencyMetadata.timezone` was already stored and loaded, but only used
for the weekday lookup in the `days_of_the_week` branch. All other date
arithmetic ran in UTC.

## Root cause

Two places in `scheduleNextDueDate()`:

1. `baseDate` was forced to UTC, so `AddDate` carried the *UTC* wall clock
   forward. Adding a day to `2026-10-24T04:45Z` gives `2026-10-25T04:45Z`,
   which is 06:45 CEST before the transition and 05:45 CET after it.
2. The time-of-day override was applied in UTC, re-pinning every recurrence
   to the same UTC hour. That is why the drift is permanent rather than
   self-correcting.

## The change

Evaluate the whole schedule in the chore's own location and convert to UTC
only at the return points, which is what storage expects.

- A `choreLocation(ctx, chore)` helper replaces the timezone-loading block
  that was previously inlined in the `days_of_the_week` branch, so the
  logic lives in one place.
- `baseDate` is built with `.In(loc)`, so `AddDate` preserves the local wall
  clock across transitions — Go's documented behaviour for location-aware
  times.
- The time-of-day override uses `loc` instead of `time.UTC`.
- Each return path normalises back to UTC.

## Backwards compatibility

With an empty `frequencyMetadata.timezone`, `choreLocation` returns
`time.UTC` and every code path is arithmetically identical to before.
Chores created before timezones were stored are unaffected, and all
existing tests in `scheduler_test.go` run through that path since none of
them set a timezone.

## Tests

Five new tests in `scheduler_test.go`:

- three DST regressions — `daily` and `days_of_the_week` across the autumn
  transition, `interval` across the spring one — each failing on `develop`
  and passing with this change
- one asserting the UTC path is unchanged without a timezone
- one asserting an unparseable timezone still falls back to UTC

The test file imports `time/tzdata` so the cases run on systems without a
zoneinfo database instead of silently skipping. To confirm the regressions
actually catch the bug:

```
git stash push internal/chore/scheduler.go   # remove the fix, keep the tests
go test ./internal/chore/ -run DST -v        # the three DST tests fail
git stash pop
```

## Note on the DST gap

For the hour a spring transition skips, `time.Date` normalises to a
neighbouring instant. Go does not guarantee which one, but it does not
error either, so a chore scheduled inside that hour still gets a valid due
date. Called out in a comment at the call site.

## Related observation, deliberately not part of this PR

For `frequencyType: "daily"` the time-of-day override block is never
entered, so `frequencyMetadata.time` is ignored entirely and the time comes
from `nextDueDate`. That may be intentional, but it does mean the `time`
value has no effect on daily chores, which is surprising via the API. Happy
to file it separately if you consider it a bug.
