### PR TITLE
Add codespell config, CI, and fix existing typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,8 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,*.svg,go.sum,.codespellrc
+skip = .git,.git-meta,.gitignore,.gitattributes,*.svg,go.sum,go.mod,.codespellrc,frontend/dist
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+# Ignore camelCase and PascalCase code identifiers
+ignore-regex = \b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
+# fo: vim modeline formatoptions flag in .goreleaser.yaml
+ignore-words-list = fo

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,*.svg,go.sum,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -131,7 +131,7 @@ func NewAuthMiddleware(cfg *config.Config, userRepo *uRepo.UserRepository, mfaSe
 					WebhookURL: user.WebhookURL,
 				}, nil
 			case "3rdPartyAuth":
-				// we should only reach this stage if a handler mannually call authenticator with it's context:
+				// we should only reach this stage if a handler manually call authenticator with it's context:
 
 				var authObject *uModel.UserDetails
 				v := c.Value("user_account")

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -546,7 +546,7 @@ func (h *Handler) CreateChore(c *gin.Context) {
 		IsPrivate:              *choreReq.IsPrivate,
 		ProjectID:              choreReq.ProjectID,
 		// SubTasks removed to prevent duplicate creation - handled by UpdateSubtask call below
-		// it's need custom logic to handle subtask creation as we send negative ids sometimes when we creating parent child releationship
+		// it's need custom logic to handle subtask creation as we send negative ids sometimes when we creating parent child relationship
 		// when the subtask is not yet created
 	}
 	id, err := h.choreRepo.CreateChore(c, createdChore)

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -903,7 +903,7 @@ func (r *ChoreRepository) GetOverdueChoresForNotification(c context.Context, ove
 	return chores, nil
 }
 
-// a predue notfication is a notification send before the due date in 6 hours, 3 hours :
+// a predue notification is a notification send before the due date in 6 hours, 3 hours :
 func (r *ChoreRepository) GetPreDueChoresForNotification(c context.Context, preDueDuration time.Duration, everyDuration time.Duration) ([]*chModel.Chore, error) {
 	var chores []*chModel.Chore
 	query := r.db.WithContext(c).Table("chores").Select("chores.*, MAX(n.created_at) as max_notification_created_at").Joins("left join notifications n on n.chore_id = chores.id and n.scheduled_for = chores.next_due_date and n.type = 3")

--- a/internal/database/migrations/20241123_initial_sql_script.sql
+++ b/internal/database/migrations/20241123_initial_sql_script.sql
@@ -1,2 +1,2 @@
 -- +migrate Up
--- nothing here just to include in he embeded sql :) 
+-- nothing here just to include in the embedded sql :)

--- a/internal/events/producer.go
+++ b/internal/events/producer.go
@@ -93,7 +93,7 @@ func (p *EventsProducer) processEvent(event Event) {
 		return
 	}
 
-	// Pring the event and the url:
+	// Print the event and the url:
 	p.logger.Debug("Sending event to webhook", "url", event.URL, "event", event)
 	p.logger.Debug("Event: ", event)
 

--- a/migrations/20250314_fix_notification_metadata_experiment_modal.go
+++ b/migrations/20250314_fix_notification_metadata_experiment_modal.go
@@ -31,7 +31,7 @@ func (m MigrateFixNotificationMetadataExperimentModal20241212) Up(ctx context.Co
 			return nil
 		}
 
-		// Update all chore where notification metadata is a null stirng 'null' to empty json {}:
+		// Update all chore where notification metadata is a null string 'null' to empty json {}:
 		if err := tx.Table("chores").Where("notification_meta = ?", "null").Update("notification_meta", "{}").Error; err != nil {
 			log.Errorf("Failed to update chores with null notification metadata: %v", err)
 			return err

--- a/migrations/20250406_frequency_metadata_v2_and_notification_metadata_v2.go
+++ b/migrations/20250406_frequency_metadata_v2_and_notification_metadata_v2.go
@@ -50,7 +50,7 @@ func (m MigrateFrequencyMetadataV2AndNotificationMetadataV2Migration20250406) Up
 	}
 	// Start a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Update all chore where notification metadata is a null stirng 'null' to empty json {}:
+		// Update all chore where notification metadata is a null string 'null' to empty json {}:
 
 		// if err := tx.Table("chores").Where("notification_meta = ?", "null").Update("notification_meta", "{}").Error; err != nil {
 		// 	log.Errorf("Failed to update chores with null notification metadata: %v", err)


### PR DESCRIPTION
Add [codespell](https://github.com/codespell-project/codespell) spell-checking to the repo and fix the typos it surfaced.

I've introduced codespell to over a hundred projects with a mostly positive reception — see the [improveit-dashboard notes](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md) for background. The CI workflow has `permissions: contents: read`, so it should be safe.

The initial two commits on this branch (`Add rudimentary codespell config` and `Add GitHub Actions workflow ...`) were already present when I started; the three new commits tune the config and fix the actual typos.

## Summary of changes

### Config tuning (`8aa9ed4`)

- **Skip** `frontend/dist` (compiled bundle), `go.mod` (dep pins that look like typos), and `.git-meta` (per-repo scratch folder for commit / PR message drafts).
- **`ignore-regex`** for camelCase / PascalCase code identifiers that are otherwise flagged as typos (`userA`, `everyTime`, `HasTable`, etc.).
- **`ignore-words-list = fo`** for the vim modeline `fo=cnqoj` (formatoptions flag) in `.goreleaser.yaml`.

### Typo fixes

All fixes are in **code comments** (or the SQL comment on line 2 of the initial migration). No behavioural changes.

| File | Change |
| --------------------------------------------------------------------- | ------------------------------- |
| `internal/auth/middleware.go:134`                                     | `mannually` → `manually`        |
| `internal/chore/handler.go:549`                                       | `releationship` → `relationship`|
| `internal/chore/repo/repository.go:906`                               | `notfication` → `notification`  |
| `internal/database/migrations/20241123_initial_sql_script.sql:2`      | `he embeded` → `the embedded`   |
| `internal/events/producer.go:96`                                      | `Pring` → `Print`               |
| `migrations/20250314_..._experiment_modal.go:34`                      | `stirng` → `string`             |
| `migrations/20250406_frequency_metadata_v2_..._v2.go:53`              | `stirng` → `string`             |

<details><summary>How the fixes were split across commits</summary>

- `865c87f` — the two fixes that needed human judgment:
  - `Pring` in `producer.go` was ambiguous (`Print / Bring / Ping / Spring`); context is `p.logger.Debug("Sending event to webhook", ...)` so `Print` was clear.
  - `he embeded` in the SQL migration is really two typos on one line — codespell caught `embeded` but not `he` (it's a real word), so folded them into one manual edit.
- `611180b` — the remaining 5 single-suggestion typos, applied via `codespell -w` and recorded under `datalad run` provenance so the exact command is reproducible from git metadata.

</details>

<details><summary>Notes for reviewers</summary>

- **`Referer` in `main.go:271` is intentional** and not modified. It's the canonical HTTP header name — the misspelling is baked into RFC 1945/2616 and every HTTP library. Codespell's default dictionaries do not flag it; only the extended `--builtin usage` bucket does.
- The docs URL `https://docs.donetick.com/getting-started/configration` on the external docs site contains a typo (`configration`) — but that's rendered by a separate docs repository, not from anything in this tree. Worth fixing over there separately. But that is what brought me here...

</details>

## Historical context

`git log --grep=typo` shows **4 prior manual typo-fix commits / PRs** landed on `develop` (e.g. #295 `fix: 'Notificaiton' should be 'Notification'`, #91 `dev/fix-typos`). Automated checking on every PR should catch these before they land.

## Test plan

- [x] `codespell` exits 0 on the tree (`uvx codespell` — zero errors)
- [x] Extended-dictionary pass (`uvx codespell --builtin clear,rare,usage,code,names`) reviewed — only `Referer` (intentional, see above)
- [x] Full diff reviewed for false positives (regex patterns, variable names) — none
- [ ] CI (`Codespell` workflow) passes on this PR
