### PR TITLE
fix(chore): allow circle admins and managers to delete chores via eapi

### DIFF
--- a/internal/chore/api.go
+++ b/internal/chore/api.go
@@ -413,8 +413,17 @@ func (h *API) DeleteChore(c *gin.Context) {
 		return
 	}
 	if chore.CreatedBy != currentUser.ID {
-		c.JSON(403, gin.H{"error": "You can only delete your own chores"})
-		return
+		// Circle admins and managers may delete chores created by other members,
+		// consistent with UpdateChore above (CanEdit) and DeleteChoreHistory.
+		circleUsers, err := h.circleRepo.GetCircleUsers(c, currentUser.CircleID)
+		if err != nil {
+			c.JSON(500, gin.H{"error": "Failed to get circle members"})
+			return
+		}
+		if !currentUser.IsAdminOrManager(circleUsers) {
+			c.JSON(403, gin.H{"error": "You can only delete your own chores"})
+			return
+		}
 	}
 	if _, err := h.choreRepo.DeleteChore(c, choreID); err != nil {
 		c.JSON(500, gin.H{"error": "Failed to delete chore"})

--- a/internal/chore/api_delete_permission_test.go
+++ b/internal/chore/api_delete_permission_test.go
@@ -1,0 +1,53 @@
+package chore
+
+import (
+	"testing"
+
+	cModel "donetick.com/core/internal/circle/model"
+	uModel "donetick.com/core/internal/user/model"
+)
+
+// TestAPIDeleteChorePermission covers the authorization rule used by
+// (*API).DeleteChore for the eapi/v1/chore endpoint: the chore creator may
+// always delete, and circle admins/managers may delete chores created by
+// other members.
+func TestAPIDeleteChorePermission(t *testing.T) {
+	const (
+		creatorID = 1
+		otherID   = 2
+	)
+
+	circleUsers := func(role cModel.UserRole) []*cModel.UserCircleDetail {
+		return []*cModel.UserCircleDetail{
+			{UserCircle: cModel.UserCircle{UserID: creatorID, Role: cModel.UserRoleAdmin}},
+			{UserCircle: cModel.UserCircle{UserID: otherID, Role: role}},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		userID      int
+		role        cModel.UserRole
+		wantAllowed bool
+	}{
+		{name: "creator can delete own chore", userID: creatorID, role: cModel.UserRoleAdmin, wantAllowed: true},
+		{name: "admin can delete another member's chore", userID: otherID, role: cModel.UserRoleAdmin, wantAllowed: true},
+		{name: "manager can delete another member's chore", userID: otherID, role: cModel.UserRoleManager, wantAllowed: true},
+		{name: "member cannot delete another member's chore", userID: otherID, role: cModel.UserRoleMember, wantAllowed: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			users := circleUsers(test.role)
+			user := uModel.UserDetails{User: uModel.User{ID: test.userID}}
+
+			// Mirrors the handler: creator short-circuits, otherwise the
+			// admin/manager role decides.
+			allowed := creatorID == test.userID || user.IsAdminOrManager(users)
+
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v", allowed, test.wantAllowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `eapi/v1/chore` DELETE endpoint only allows the chore **creator** to delete a
chore. Integrations that authenticate with a single API token therefore cannot
delete chores created by anyone else, even when the token's account is an admin or
manager of the circle.

This is the same restriction reported in #760, but in a **different handler**.
#760 and PR #788 address `(*Handler).DeleteChore` in `internal/chore/handler.go`
(error: `"You are not allowed to delete this chore"`). The external API has its own
`(*API).DeleteChore` in `internal/chore/api.go` with a separate check and a
different error string (`"You can only delete your own chores"`), which #788 does
not touch. The two changes are complementary and do not overlap.

The inconsistency is visible within `api.go` itself: `(*API).UpdateChore`
immediately above already does a role-aware check via `CanEdit(user.ID, circleUsers, &now)`,
so an admin can *edit* another member's chore through the eapi but not *delete* it.

## Change

`internal/chore/api.go` — when the caller is not the creator, load the circle users
and allow the delete if the caller is an admin or manager. Plain members are still
refused with the original 403 and message.

This reuses the existing `UserDetails.IsAdminOrManager` helper
(`internal/user/model/model.go`), already used by `DeleteChoreHistory`, so no new
permission abstraction is introduced. 11 insertions.

## Why this matters in practice

This surfaced through the Home Assistant integration, which holds one API token for
the whole household. Every request reaches Donetick as that single account, so no
member could delete a chore that another member had created in the web UI — the
integration reports it as an opaque HTTP 500.

## Testing

Added `internal/chore/api_delete_permission_test.go`, a table-driven test in the
style of the existing `handler_test.go`, covering creator / admin / manager / member.

```
$ go test ./internal/chore/...
ok    donetick.com/core/internal/chore      0.018s
ok    donetick.com/core/internal/chore/repo 0.068s
$ go vet ./internal/chore/...   # clean
$ gofmt -l internal/chore/api.go   # no output
```

Also verified end-to-end against a running server (sqlite, two users in one circle,
chores created by user 1 via `eapi/v1/chore`), comparing binaries built from this
branch and from `main` on the **same database**:

| Case | `main` | this branch |
|---|---|---|
| creator deletes own chore | 200 | 200 |
| **admin** deletes another member's chore | **403** | **200** |
| **member** deletes another member's chore | 403 | **403** (unchanged) |

## Note

I'd happily fold this into #788 instead if you prefer a single PR for #760 — it is
the same decision applied to the second handler. Since #760 carries a `decision`
label, I'm treating the policy as yours to make; this change only aligns the eapi
endpoint with the role model already used elsewhere in the same file.
