### PR TITLE
feat(chores): auto-skip repeating tasks once they are late

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -140,9 +140,11 @@ type ServerConfig struct {
 }
 
 type SchedulerConfig struct {
-	DueJob     time.Duration `mapstructure:"due_job" yaml:"due_job"`
-	OverdueJob time.Duration `mapstructure:"overdue_job" yaml:"overdue_job"`
-	PreDueJob  time.Duration `mapstructure:"pre_due_job" yaml:"pre_due_job"`
+	DueJob              time.Duration `mapstructure:"due_job" yaml:"due_job"`
+	OverdueJob          time.Duration `mapstructure:"overdue_job" yaml:"overdue_job"`
+	PreDueJob           time.Duration `mapstructure:"pre_due_job" yaml:"pre_due_job"`
+	AutoSkipJob         time.Duration `mapstructure:"auto_skip_job" yaml:"auto_skip_job"`
+	AutoSkipGracePeriod time.Duration `mapstructure:"auto_skip_grace_period" yaml:"auto_skip_grace_period"`
 }
 
 type StripeConfig struct {

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -48,6 +48,8 @@ scheduler_jobs:
   due_job: 30m
   overdue_job: 3h
   pre_due_job: 3h
+  auto_skip_job: 5m
+  auto_skip_grace_period: 0s
 email:
   host:
   port:

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -42,6 +42,8 @@ scheduler_jobs:
   due_job: 30m
   overdue_job: 3h
   pre_due_job: 3h
+  auto_skip_job: 5m
+  auto_skip_grace_period: 0s
 email:
   host:
   port:

--- a/internal/chore/autoskip.go
+++ b/internal/chore/autoskip.go
@@ -1,0 +1,159 @@
+package chore
+
+import (
+	"context"
+	"time"
+
+	"donetick.com/core/config"
+	chModel "donetick.com/core/internal/chore/model"
+	chRepo "donetick.com/core/internal/chore/repo"
+	cRepo "donetick.com/core/internal/circle/repo"
+	"donetick.com/core/internal/events"
+	nps "donetick.com/core/internal/notifier/service"
+	"donetick.com/core/internal/realtime"
+	uRepo "donetick.com/core/internal/user/repo"
+	"donetick.com/core/logging"
+)
+
+const (
+	defaultAutoSkipInterval   = 5 * time.Minute
+	maxAutoSkipPerChorePerRun = 10
+)
+
+type AutoSkipService struct {
+	choreRepo       *chRepo.ChoreRepository
+	circleRepo      *cRepo.CircleRepository
+	userRepo        *uRepo.UserRepository
+	nPlanner        *nps.NotificationPlanner
+	eventProducer   *events.EventsProducer
+	realTimeService *realtime.RealTimeService
+	interval        time.Duration
+	gracePeriod     time.Duration
+	done            chan struct{}
+}
+
+func NewAutoSkipService(cfg *config.Config, cr *chRepo.ChoreRepository, circleRepo *cRepo.CircleRepository,
+	ur *uRepo.UserRepository, np *nps.NotificationPlanner, ep *events.EventsProducer,
+	rts *realtime.RealTimeService) *AutoSkipService {
+	interval := cfg.SchedulerJobs.AutoSkipJob
+	if interval <= 0 {
+		interval = defaultAutoSkipInterval
+	}
+	gracePeriod := cfg.SchedulerJobs.AutoSkipGracePeriod
+	if gracePeriod < 0 {
+		gracePeriod = 0
+	}
+	return &AutoSkipService{
+		choreRepo:       cr,
+		circleRepo:      circleRepo,
+		userRepo:        ur,
+		nPlanner:        np,
+		eventProducer:   ep,
+		realTimeService: rts,
+		interval:        interval,
+		gracePeriod:     gracePeriod,
+		done:            make(chan struct{}),
+	}
+}
+
+func (s *AutoSkipService) Start(ctx context.Context) {
+	logging.FromContext(ctx).Infow("Auto skip service started", "interval", s.interval.String(), "gracePeriod", s.gracePeriod.String())
+	go func() {
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+		s.run(ctx)
+		for {
+			select {
+			case <-s.done:
+				logging.FromContext(ctx).Info("Auto skip service stopped")
+				return
+			case <-ticker.C:
+				s.run(ctx)
+			}
+		}
+	}()
+}
+
+func (s *AutoSkipService) Stop() {
+	close(s.done)
+}
+
+func (s *AutoSkipService) run(ctx context.Context) {
+	log := logging.FromContext(ctx)
+	cutoff := time.Now().UTC().Add(-s.gracePeriod)
+
+	chores, err := s.choreRepo.GetChoresDueForAutoSkip(ctx, cutoff)
+	if err != nil {
+		log.Errorw("Failed to load chores due for auto skip", "error", err)
+		return
+	}
+	if len(chores) == 0 {
+		return
+	}
+	log.Debugw("Auto skipping late chores", "count", len(chores))
+	for _, chore := range chores {
+		if err := s.autoSkipChore(ctx, chore, cutoff); err != nil {
+			log.Errorw("Failed to auto skip chore", "choreID", chore.ID, "error", err)
+		}
+	}
+}
+
+func (s *AutoSkipService) autoSkipChore(ctx context.Context, chore *chModel.Chore, cutoff time.Time) error {
+	log := logging.FromContext(ctx)
+	performerID := chore.CreatedBy
+	if chore.AssignedTo != nil && *chore.AssignedTo > 0 {
+		performerID = *chore.AssignedTo
+	}
+
+	skipped := 0
+	for skipped < maxAutoSkipPerChorePerRun {
+		if chore.NextDueDate == nil || !chore.NextDueDate.UTC().Before(cutoff) {
+			break
+		}
+		previousDueDate := chore.NextDueDate.UTC()
+		nextDueDate, err := scheduleNextDueDate(ctx, chore, previousDueDate)
+		if err != nil {
+			return err
+		}
+		if nextDueDate == nil || !nextDueDate.After(previousDueDate) {
+			log.Warnw("Auto skip could not advance the due date, leaving chore untouched", "choreID", chore.ID, "frequencyType", chore.FrequencyType)
+			break
+		}
+		if err := s.choreRepo.SkipChore(ctx, chore, performerID, nextDueDate, chore.AssignedTo, nil); err != nil {
+			return err
+		}
+		chore.NextDueDate = nextDueDate
+		skipped++
+	}
+	if skipped == 0 {
+		return nil
+	}
+
+	updatedChore, err := s.choreRepo.GetChore(ctx, chore.ID, performerID, chore.CircleID)
+	if err != nil {
+		return err
+	}
+	log.Infow("Auto skipped late chore", "choreID", chore.ID, "occurrences", skipped, "nextDueDate", updatedChore.NextDueDate)
+
+	s.nPlanner.GenerateNotifications(ctx, updatedChore)
+
+	performer, err := s.userRepo.GetUserByID(ctx, performerID)
+	if err != nil {
+		log.Errorw("Failed to load the user an auto skip is attributed to", "userID", performerID, "error", err)
+		return nil
+	}
+
+	if circle, err := s.circleRepo.GetCircleByID(ctx, chore.CircleID); err == nil && circle.WebhookURL != nil {
+		s.eventProducer.ChoreSkipped(ctx, circle.WebhookURL, updatedChore, performer)
+	}
+
+	if s.realTimeService != nil {
+		history, _ := s.choreRepo.GetChoreHistoryWithLimit(ctx, chore.ID, 1)
+		var choreHistory *chModel.ChoreHistory
+		if len(history) > 0 {
+			choreHistory = history[0]
+		}
+		s.realTimeService.GetEventBroadcaster().BroadcastChoreSkipped(updatedChore, performer, choreHistory, nil)
+	}
+	return nil
+}

--- a/internal/chore/handler.go
+++ b/internal/chore/handler.go
@@ -311,6 +311,7 @@ type ChoreReq struct {
 	FrequencyMetadata    *chModel.FrequencyMetadata    `json:"frequencyMetadata,omitempty"`
 	NextDueDate          *time.Time                    `json:"nextDueDate" binding:"omitempty,required_with=IsRolling"` // Next due date in RFC3339 format
 	IsRolling            bool                          `json:"isRolling"`
+	AutoSkipWhenLate     bool                          `json:"autoSkipWhenLate"`
 	AssignedTo           *int                          `json:"assignedTo" binding:"omitempty"`
 	Assignees            []chModel.ChoreAssignees      `json:"assignees" binding:"dive"`
 	AssignStrategy       chModel.AssignmentStrategy    `json:"assignStrategy" binding:"required,oneof=no_assignee least_assigned least_completed random keep_last_assigned random_except_last_assigned round_robin"`
@@ -531,6 +532,7 @@ func (h *Handler) CreateChore(c *gin.Context) {
 		AssignStrategy:         choreReq.AssignStrategy,
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
+		AutoSkipWhenLate:       choreReq.AutoSkipWhenLate,
 		UpdatedBy:              currentUser.ID,
 		IsActive:               *choreReq.IsActive,
 		Notification:           choreReq.Notification,
@@ -838,6 +840,7 @@ func (h *Handler) EditChore(c *gin.Context) {
 		AssignStrategy:         choreReq.AssignStrategy,
 		AssignedTo:             choreReq.AssignedTo,
 		IsRolling:              choreReq.IsRolling,
+		AutoSkipWhenLate:       choreReq.AutoSkipWhenLate,
 		IsActive:               *choreReq.IsActive,
 		Notification:           choreReq.Notification,
 		NotificationMetadataV2: choreReq.NotificationMetadata,

--- a/internal/chore/model/model.go
+++ b/internal/chore/model/model.go
@@ -53,6 +53,7 @@ type Chore struct {
 	FrequencyMetadataV2    *FrequencyMetadata         `json:"frequencyMetadata" gorm:"column:frequency_meta_v2;type:json"`                            // Additional frequency information for v2 (if used)
 	NextDueDate            *time.Time                 `json:"nextDueDate" gorm:"column:next_due_date;index"`                                          // When the chore is due
 	IsRolling              bool                       `json:"isRolling" gorm:"column:is_rolling"`                                                     // Whether the chore is rolling
+	AutoSkipWhenLate       bool                       `json:"autoSkipWhenLate" gorm:"column:auto_skip_when_late;default:false"`                       // Whether an overdue occurrence is skipped automatically
 	AssignedTo             *int                       `json:"assignedTo" gorm:"column:assigned_to"`                                                   // Who the chore is assigned to
 	Assignees              []ChoreAssignees           `json:"assignees" gorm:"foreignkey:ChoreID;references:ID"`                                      // Assignees of the chore
 	AssignStrategy         AssignmentStrategy         `json:"assignStrategy" gorm:"column:assign_strategy"`                                           // How the chore is assigned

--- a/internal/chore/repo/repository.go
+++ b/internal/chore/repo/repository.go
@@ -913,6 +913,27 @@ func (r *ChoreRepository) GetPreDueChoresForNotification(c context.Context, preD
 	return chores, nil
 }
 
+func (r *ChoreRepository) GetChoresDueForAutoSkip(c context.Context, cutoff time.Time) ([]*chModel.Chore, error) {
+	var chores []*chModel.Chore
+	if err := r.db.WithContext(c).
+		Model(&chModel.Chore{}).
+		Where("auto_skip_when_late = ?", true).
+		Where("is_active = ?", true).
+		Where("next_due_date IS NOT NULL AND next_due_date < ?", cutoff).
+		Where("status NOT IN ?", []chModel.Status{chModel.ChoreStatusPaused, chModel.ChoreStatusPendingApproval}).
+		Where("frequency_type NOT IN ?", []chModel.FrequencyType{
+			chModel.FrequencyTypeOnce,
+			chModel.FrequencyTypeNoRepeat,
+			chModel.FrequencyTypeTrigger,
+			chModel.FrequencyTypeAdaptive,
+		}).
+		Order("next_due_date asc").
+		Find(&chores).Error; err != nil {
+		return nil, err
+	}
+	return chores, nil
+}
+
 func readJSONBooleanField(dbType string, columnName string, fieldName string) clause.Expr {
 	if dbType == "postgres" {
 		return gorm.Expr("("+columnName+"::json->>?)::boolean", fieldName)

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 		// add handlers also
 		fx.Provide(newServer),
 		fx.Provide(notifier.NewScheduler),
+		fx.Provide(chore.NewAutoSkipService),
 
 		// things
 		fx.Provide(tRepo.NewThingRepository),
@@ -228,7 +229,7 @@ func main() {
 
 }
 
-func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, notifier *notifier.Scheduler, eventProducer *events.EventsProducer, mfaCleanup *mfa.CleanupService, authCleanup *auth.CleanupService, rts *realtime.RealTimeService, draftCleanup *storage.DraftCleanupService, ticketStore *realtime.TicketStore) *gin.Engine {
+func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, notifier *notifier.Scheduler, eventProducer *events.EventsProducer, mfaCleanup *mfa.CleanupService, authCleanup *auth.CleanupService, rts *realtime.RealTimeService, draftCleanup *storage.DraftCleanupService, ticketStore *realtime.TicketStore, autoSkip *chore.AutoSkipService) *gin.Engine {
 	// Set Gin mode based on logging configuration
 	if cfg.Logging.Development || strings.ToLower(cfg.Logging.Level) == "debug" {
 		gin.SetMode(gin.DebugMode)
@@ -291,6 +292,7 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, notifier *notif
 			mfaCleanup.Start(context.Background())
 			authCleanup.Start(context.Background())
 			draftCleanup.Start(context.Background())
+			autoSkip.Start(context.Background())
 
 			// Start real-time service
 			if err := rts.Start(ctx); err != nil {
@@ -323,6 +325,7 @@ func newServer(lc fx.Lifecycle, cfg *config.Config, db *gorm.DB, notifier *notif
 			mfaCleanup.Stop()
 			authCleanup.Stop()
 			draftCleanup.Stop()
+			autoSkip.Stop()
 
 			// Stop the SSE ticket store cleanup goroutine
 			ticketStore.Stop()


### PR DESCRIPTION
Adds a per-chore autoSkipWhenLate flag and a background job that skips overdue occurrences of chores that opt in, reusing the existing skip path so history, webhooks and real-time events stay consistent.

One-off, no-repeat, trigger and adaptive chores are excluded, so a task is only ever rolled forward when there is a next occurrence to roll to.

Frontend pr: https://github.com/donetick/frontend/pull/245
https://github.com/donetick/donetick/discussions/364