### PR TITLE
fix: honor single_circle_instance for password-based signup

### DIFF
--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -170,14 +170,30 @@ func (h *Handler) signUp(c *gin.Context) {
 		})
 		return
 	}
-	// var userCircle *circle.Circle
-	// var userRole string
-	userCircle, err := h.circleRepo.CreateCircle(c, &cModel.Circle{
-		Name:       signupReq.DisplayName + "'s circle",
-		CreatedAt:  time.Now().UTC(),
-		UpdatedAt:  time.Now().UTC(),
-		InviteCode: utils.GenerateInviteCode(c),
-	})
+	var userCircle *cModel.Circle
+	role := cModel.UserRoleAdmin
+	if h.singleCircleInstance {
+		// In single-circle mode, every signup joins the shared household circle
+		// (ID 1) instead of getting its own. The first signup bootstraps it.
+		userCircle, err = h.circleRepo.GetCircleByID(c, 1)
+		if err != nil {
+			userCircle, err = h.circleRepo.CreateCircle(c, &cModel.Circle{
+				Name:       "Home",
+				CreatedAt:  time.Now().UTC(),
+				UpdatedAt:  time.Now().UTC(),
+				InviteCode: utils.GenerateInviteCode(c),
+			})
+		} else {
+			role = cModel.UserRoleMember
+		}
+	} else {
+		userCircle, err = h.circleRepo.CreateCircle(c, &cModel.Circle{
+			Name:       signupReq.DisplayName + "'s circle",
+			CreatedAt:  time.Now().UTC(),
+			UpdatedAt:  time.Now().UTC(),
+			InviteCode: utils.GenerateInviteCode(c),
+		})
+	}
 
 	if err != nil {
 		c.JSON(500, gin.H{
@@ -189,7 +205,7 @@ func (h *Handler) signUp(c *gin.Context) {
 	if err := h.circleRepo.AddUserToCircle(c, &cModel.UserCircle{
 		UserID:    insertedUser.ID,
 		CircleID:  userCircle.ID,
-		Role:      "admin",
+		Role:      role,
 		IsActive:  true,
 		CreatedAt: time.Now().UTC(),
 		UpdatedAt: time.Now().UTC(),


### PR DESCRIPTION
`single_circle_instance` was only checked in the OAuth2 signup path `thirdPartyAuthCallback`, so a self-hosted instance configured for a single shared circle still created a brand new circle for every user signing up with a username/password, defeating the setting entirely for those using password-based auth.

For password sing-ups, `signUp` now behaves as follows when `singleCircleInstance` is set:

- If circle id: 1 exists, users signing up  join that circle with the standard User role
- If circle id: 1 is not found on the instance, a signup will trigger ti to be created as "Home" and the user signing up receives the Admin role.

This is a simple default behavior as password signups offer no group claims to base role assignment on.



Also worth noting that anyone attempting to use `singleCircleInstance` with google sign-ins will still get the new circle per user behavior, however this is not addressed in this PR.