### PR TITLE
fix: correct DT_EMAIL_APP_HOST env var mismatch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -194,7 +194,9 @@ type EmailConfig struct {
 	Key       string `mapstructure:"key"`
 	Host      string `mapstructure:"host"`
 	Port      int    `mapstructure:"port"`
-	AppHost   string `mapstructure:"appHost"`
+	// Renamed from "appHost" to match this struct's snake_case convention;
+	// see the legacy fallback in LoadConfig.
+	AppHost   string `mapstructure:"app_host" yaml:"app_host"`
 	LogRawURL bool   `mapstructure:"log_raw_url" yaml:"log_raw_url"`
 	// Provider selects which email sender implementation to use.
 	// "smtp" (default, empty also means smtp) uses host/port/user/key as SMTP creds.
@@ -371,6 +373,13 @@ func LoadConfig() *Config {
 	err = viper.Unmarshal(&config)
 	if err != nil {
 		panic(err)
+	}
+
+	// Legacy fallback for YAML configs still using the old "appHost" key.
+	if config.EmailConfig.AppHost == "" {
+		if legacy := viper.GetString("email.appHost"); legacy != "" {
+			config.EmailConfig.AppHost = legacy
+		}
 	}
 
 	// Apply default values for fields with default tags

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -54,7 +54,7 @@ email:
   key:
   email:
   user:
-  appHost:
+  app_host:
   log_raw_url: true # log password reset URL to console (useful when email is not configured)
 mfa:
   session_timeout: 10m

--- a/config/selfhosted.yaml
+++ b/config/selfhosted.yaml
@@ -48,7 +48,7 @@ email:
   key:
   email:
   user: # optional, will be filled with email.email if not set.
-  appHost:
+  app_host:
   log_raw_url: true # log password reset URL to console (useful when email is not configured)
 oauth2:
   client_id:


### PR DESCRIPTION
`EmailConfig.AppHost` was tagged `mapstructure:"appHost"`, unlike every other key in this struct - so viper's actual derived env var was `DT_EMAIL_APPHOST`, not the documented/exported `DT_EMAIL_APP_HOST`. The existing tag never picked up `DT_EMAIL_APP_HOST` at all, so any deployments setting that environment variable (including the HA add-on) had it silently ignored, producing broken password-reset URLs.

Renamed to app_host to match the file's snake_case convention, updated the example selfhosted.yaml/local.yaml configs, and added a fallback in LoadConfig for YAML files still using the old "appHost" key so existing file-based configs aren't broken by this PR.

Fixes donetick/hassio-addons#40